### PR TITLE
feat(storage): add samples for soft delete (objects) 

### DIFF
--- a/pubsub/api/README.md
+++ b/pubsub/api/README.md
@@ -64,6 +64,67 @@ Usage: create_topic.php $projectId $topicName
 	@param string $topicName  The Pub/Sub topic name.
 ```
 
+## PHPUnit Tests
+
+At this time, the GitHub actions in this repo fail to run the tests written in this folder. The developer is responsible for locally running and confirming their samples and corresponding tests.
+
+### PubSub Emulator
+Some tests in the pubsubTest.php requires PubSub emulator. These tests start with ```$this->requireEnv('PUBSUB_EMULATOR_HOST')```.
+
+#### Prerequisites
+- Python
+```
+xcode-select --install
+brew install pyenv
+pyenv install <version>
+python3 --version
+```
+- JDK
+```
+brew install openjdk
+export JAVA_HOME=<path to openjdk folder>
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+Once python, JDK, and GCloud CLI are installed, follow [these instructions](https://cloud.google.com/pubsub/docs/emulator) to run the emulator.
+
+### Setting up environment variables
+Open a new tab in terminal, separate from the one running your emulator.
+
+```
+// php-docs-samples/testing folder
+$ cd ../../../testing
+
+$ export GOOGLE_PROJECT_ID=<project id>
+$ export GOOGLE_PUBSUB_TOPIC=<topic name>
+$ export GOOGLE_PUBSUB_STORAGE_BUCKET=<bucket name>
+$ export GOOGLE_PUBSUB_SUBSCRIPTION=<subscription name>
+
+// only set if your test requires the emulator
+$ export PUBSUB_EMULATOR_HOST=localhost:<emulator port>
+
+// unset the PUBSUB emulator host variable if you want to run a test that doesn't require an emulator
+$ unset PUBSUB_EMULATOR
+```
+
+### Running the tests
+Run your test(s) like so in the same terminal tab that you set your env variables in the previous step.
+
+```
+// Run all tests in pubsubTest.php. --verbose tag is recommended to see any issues or stack trace
+$ php-docs-samples/testing/vendor/bin/phpunit ../pubsub/api/test/pubsubTest.php --verbose
+
+// Run a single test in pubsubTest.php
+$ php-docs-samples/testing/vendor/bin/phpunit ../pubsub/api/test/pubsubTest.php --filter testSubscriptionPolicy --verbose
+```
+
+## Fixing Styling Errors
+If you create a PR and the Lint / styles (pull_request) check fails, this is a quick fix.
+
+```
+$ php-docs-samples/testing/vendor/bin/php-cs-fixer fix <path to your file>
+```
+
 ## Troubleshooting
 
 If you get the following error, set the environment variable `GCLOUD_PROJECT` to your project ID:

--- a/pubsub/api/src/create_topic_with_aws_msk_ingestion.php
+++ b/pubsub/api/src/create_topic_with_aws_msk_ingestion.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_create_topic_with_aws_msk_ingestion]
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Creates a Pub/Sub topic with AWS MSK ingestion.
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $clusterArn  The Amazon Resource Name (ARN) that uniquely identifies the cluster.
+ * @param string $mskTopic  The name of the topic in the Amazon MSK cluster that Pub/Sub will import from.
+ * @param string $awsRoleArn  AWS role ARN to be used for Federated Identity authentication with Amazon MSK.
+ *               Check the Pub/Sub docs for how to set up this role and the required permissions that need to be
+ *               attached to it.
+ * @param string $gcpServiceAccount  The GCP service account to be used for Federated Identity authentication
+ *               with Amazon MSK (via a AssumeRoleWithWebIdentity call for the provided role). The aws_role_arn
+ *               must be set up with accounts.google.com:sub equals to this service account number.
+ */
+function create_topic_with_aws_msk_ingestion(
+    string $projectId,
+    string $topicName,
+    string $clusterArn,
+    string $mskTopic,
+    string $awsRoleArn,
+    string $gcpServiceAccount
+): void {
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+
+    $topic = $pubsub->createTopic($topicName, [
+        'ingestionDataSourceSettings' => [
+            'aws_msk' => [
+                'cluster_arn' => $clusterArn,
+                'topic' => $mskTopic,
+                'aws_role_arn' => $awsRoleArn,
+                'gcp_service_account' => $gcpServiceAccount
+            ]
+        ]
+    ]);
+
+    printf('Topic created: %s' . PHP_EOL, $topic->name());
+}
+# [END pubsub_create_topic_with_aws_msk_ingestion]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/src/create_topic_with_cloud_storage_ingestion.php
+++ b/pubsub/api/src/create_topic_with_cloud_storage_ingestion.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_create_topic_with_cloud_storage_ingestion]
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\V1\IngestionDataSourceSettings\CloudStorage\AvroFormat;
+use Google\Cloud\PubSub\V1\IngestionDataSourceSettings\CloudStorage\PubSubAvroFormat;
+use Google\Cloud\PubSub\V1\IngestionDataSourceSettings\CloudStorage\TextFormat;
+use Google\Protobuf\Timestamp;
+
+/**
+ * Creates a topic with Cloud Storage Ingestion.
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $bucket  Cloud Storage bucket.
+ * @param string $inputFormat  Input format for the Cloud Storage data. Must be one of text, avro, or pubsub_avro.
+ * @param string $minimumObjectCreatedTime  Only objects with a larger or equal creation timestamp will be ingested.
+ * @param string $textDelimiter  Delimiter for text format input.
+ * @param string $matchGlob  Glob pattern used to match objects that will be ingested. If unset, all objects will be ingested.
+ */
+function create_topic_with_cloud_storage_ingestion(
+    string $projectId,
+    string $topicName,
+    string $bucket,
+    string $inputFormat,
+    string $minimumObjectCreatedTime,
+    string $textDelimiter = '',
+    string $matchGlob = ''
+): void {
+    $datetime = new \DateTimeImmutable($minimumObjectCreatedTime);
+    $timestamp = (new Timestamp())
+        ->setSeconds($datetime->getTimestamp())
+        ->setNanos($datetime->format('u') * 1000);
+
+    $cloudStorageData = [
+        'bucket' => $bucket,
+        'minimum_object_create_time' => $timestamp
+    ];
+
+    $cloudStorageData[$inputFormat . '_format'] = match($inputFormat) {
+        'text' => new TextFormat(['delimiter' => $textDelimiter]),
+        'avro' => new AvroFormat(),
+        'pubsub_avro' => new PubSubAvroFormat(),
+        default => throw new \InvalidArgumentException(
+            'inputFormat must be in (\'text\', \'avro\', \'pubsub_avro\'); got value: ' . $inputFormat
+        )
+    };
+
+    if (!empty($matchGlob)) {
+        $cloudStorageData['match_glob'] = $matchGlob;
+    }
+
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+
+    $topic = $pubsub->createTopic($topicName, [
+        'ingestionDataSourceSettings' => [
+            'cloud_storage' => $cloudStorageData
+        ]
+    ]);
+
+    printf('Topic created: %s' . PHP_EOL, $topic->name());
+}
+# [END pubsub_create_topic_with_cloud_storage_ingestion]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/src/create_unwrapped_push_subscription.php
+++ b/pubsub/api/src/create_unwrapped_push_subscription.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_create_unwrapped_push_subscription]
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Create unwrappped push subscription.
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $subscriptionId  The ID of the subscription.
+ */
+function create_unwrapped_push_subscription(
+    string $projectId,
+    string $topicName,
+    string $subscriptionId
+): void {
+
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+    $pubsub->subscribe($subscriptionId, $topicName, [
+        'pushConfig' => [
+            'no_wrapper' => [
+                'write_metadata' => true
+            ]
+        ]
+    ]);
+    printf('Unwrapped push subscription created: %s' . PHP_EOL, $subscriptionId);
+}
+# [END pubsub_create_unwrapped_push_subscription]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/src/optimistic_subscribe.php
+++ b/pubsub/api/src/optimistic_subscribe.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_optimistic_subscribe]
+use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Optimistically subscribes to a topic
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $subscriptionId  The ID of the subscription.
+ */
+function optimistic_subscribe(
+    string $projectId,
+    string $topicName,
+    string $subscriptionId
+): void {
+
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+
+    $subscription = $pubsub->subscription($subscriptionId);
+
+    try {
+        $messages = $subscription->pull();
+        foreach ($messages as $message) {
+            printf('PubSub Message: %s' . PHP_EOL, $message->data());
+            $subscription->acknowledge($message);
+        }
+    } catch (NotFoundException $e) { // Subscription is not found
+        printf('Exception Message: %s' . PHP_EOL, $e->getMessage());
+        printf('StackTrace: %s' . PHP_EOL, $e->getTraceAsString());
+        // Create subscription and retry the pull. Any messages published before subscription creation would not be received.
+        $pubsub->subscribe($subscriptionId, $topicName);
+        optimistic_subscribe($projectId, $topicName, $subscriptionId);
+    }
+}
+# [END pubsub_optimistic_subscribe]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/src/subscribe_exactly_once_delivery.php
+++ b/pubsub/api/src/subscribe_exactly_once_delivery.php
@@ -38,6 +38,8 @@ function subscribe_exactly_once_delivery(
 ): void {
     $pubsub = new PubSubClient([
         'projectId' => $projectId,
+        // use the apiEndpoint option to set a regional endpoint
+        'apiEndpoint' => 'us-west1-pubsub.googleapis.com:443'
     ]);
 
     $subscription = $pubsub->subscription($subscriptionId);

--- a/pubsub/api/src/subscriber_error_listener.php
+++ b/pubsub/api/src/subscriber_error_listener.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_subscriber_error_listener]
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Subscribes with an error listener
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $subscriptionId  The ID of the subscription.
+ */
+function subscriber_error_listener(
+    string $projectId,
+    string $topicName,
+    string $subscriptionId
+): void {
+
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+    $subscription = $pubsub->subscription($subscriptionId, $topicName);
+
+    try {
+        $messages = $subscription->pull();
+        foreach ($messages as $message) {
+            printf('PubSub Message: %s' . PHP_EOL, $message->data());
+            $subscription->acknowledge($message);
+        }
+    } catch (\Exception $e) { // Handle unrecoverable exceptions
+        printf('Exception Message: %s' . PHP_EOL, $e->getMessage());
+        printf('StackTrace: %s' . PHP_EOL, $e->getTraceAsString());
+    }
+}
+# [END pubsub_subscriber_error_listener]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/src/update_topic_type.php
+++ b/pubsub/api/src/update_topic_type.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/blob/main/pubsub/api/README.md
+ */
+
+namespace Google\Cloud\Samples\PubSub;
+
+# [START pubsub_update_topic_type]
+use Google\Cloud\PubSub\PubSubClient;
+
+/**
+ * Changes the type of a Pub/Sub topic.
+ *
+ * @param string $projectId  The Google project ID.
+ * @param string $topicName  The Pub/Sub topic name.
+ * @param string $streamArn  The Kinesis stream ARN to ingest data from.
+ * @param string $consumerArn  The Kinesis consumer ARN to used for ingestion in Enhanced Fan-Out mode. The consumer must be already created and ready to be used.
+ * @param string $awsRoleArn  AWS role ARN to be used for Federated Identity authentication with Kinesis. Check the Pub/Sub docs for how to set up this role and the required permissions that need to be attached to it.
+ * @param string $gcpServiceAccount  The GCP service account to be used for Federated Identity authentication with Kinesis (via a AssumeRoleWithWebIdentity call for the provided role). The $awsRoleArn must be set up with accounts.google.com:sub equals to this service account number.
+ */
+function update_topic_type(
+    string $projectId,
+    string $topicName,
+    string $streamArn,
+    string $consumerArn,
+    string $awsRoleArn,
+    string $gcpServiceAccount
+): void {
+    $pubsub = new PubSubClient([
+        'projectId' => $projectId,
+    ]);
+
+    $topic = $pubsub->topic($topicName);
+
+    $topic->update([
+        'ingestionDataSourceSettings' => [
+            'aws_kinesis' => [
+                'stream_arn' => $streamArn,
+                'consumer_arn' => $consumerArn,
+                'aws_role_arn' => $awsRoleArn,
+                'gcp_service_account' => $gcpServiceAccount
+            ]
+        ]
+    ], [
+        'updateMask' => [
+            'ingestionDataSourceSettings'
+        ]
+    ]);
+
+    printf('Topic updated: %s' . PHP_EOL, $topic->name());
+}
+# [END pubsub_update_topic_type]
+require_once __DIR__ . '/../../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2016 Google Inc.
  *
@@ -32,6 +33,8 @@ class PubSubTest extends TestCase
     use EventuallyConsistentTestTrait;
 
     private static $eodSubscriptionId;
+    private static $awsRoleArn = 'arn:aws:iam::111111111111:role/fake-role-name';
+    private static $gcpServiceAccount = 'fake-service-account@project.iam.gserviceaccount.com';
 
     public static function setUpBeforeClass(): void
     {
@@ -483,5 +486,27 @@ class PubSubTest extends TestCase
         ]);
         $this->assertMatchesRegularExpression('/Created subscription with ordering/', $output);
         $this->assertMatchesRegularExpression('/\"enableMessageOrdering\":true/', $output);
+    }
+
+    public function testCreateAndDeleteUnwrappedSubscription()
+    {
+        $topic = $this->requireEnv('GOOGLE_PUBSUB_TOPIC');
+        $subscription = 'test-subscription-' . rand();
+        $output = $this->runFunctionSnippet('create_unwrapped_push_subscription', [
+            self::$projectId,
+            $topic,
+            $subscription,
+        ]);
+
+        $this->assertMatchesRegularExpression('/Unwrapped push subscription created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
+
+        $output = $this->runFunctionSnippet('delete_subscription', [
+            self::$projectId,
+            $subscription,
+        ]);
+
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subscription), $output);
     }
 }

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -562,4 +562,42 @@ class PubSubTest extends TestCase
         $this->assertMatchesRegularExpression('/Exception Message/', $output);
         $this->assertMatchesRegularExpression(sprintf('/Resource not found \(resource=%s\)/', $subscription), $output);
     }
+
+    public function testOptimisticSubscribe()
+    {
+        $topic = $this->requireEnv('GOOGLE_PUBSUB_TOPIC');
+        $subcriptionId = 'test-subscription-' . rand();
+
+        $output = $this->runFunctionSnippet('optimistic_subscribe', [
+            self::$projectId,
+            $topic,
+            $subcriptionId
+        ]);
+        $this->assertMatchesRegularExpression('/Exception Message/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/Resource not found \(resource=%s\)/',  $subcriptionId), $output);
+
+        $testMessage = 'This is a test message';
+        $output = $this->runFunctionSnippet('publish_message', [
+            self::$projectId,
+            $topic,
+            $testMessage,
+        ]);
+        $this->assertMatchesRegularExpression('/Message published/', $output);
+        $output = $this->runFunctionSnippet('optimistic_subscribe', [
+            self::$projectId,
+            $topic,
+            $subcriptionId
+        ]);
+        $this->assertMatchesRegularExpression(sprintf('/PubSub Message: %s/', $testMessage), $output);
+        $this->assertDoesNotMatchRegularExpression('/Exception Message/', $output);
+        $this->assertDoesNotMatchRegularExpression(sprintf('/Resource not found \(resource=%s\)/', $subcriptionId), $output);
+
+        // Delete subscription
+        $output = $this->runFunctionSnippet('delete_subscription', [
+            self::$projectId,
+            $subcriptionId,
+        ]);
+        $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $subcriptionId), $output);
+    }
 }

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -600,4 +600,28 @@ class PubSubTest extends TestCase
         $this->assertMatchesRegularExpression('/Subscription deleted:/', $output);
         $this->assertMatchesRegularExpression(sprintf('/%s/', $subcriptionId), $output);
     }
+
+    public function testUpdateTopicType()
+    {
+        $topic = 'test-topic-' . rand();
+        $output = $this->runFunctionSnippet('create_topic', [
+            self::$projectId,
+            $topic,
+        ]);
+
+        $this->assertMatchesRegularExpression('/Topic created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+
+        $output = $this->runFunctionSnippet('update_topic_type', [
+            self::$projectId,
+            $topic,
+            'arn:aws:kinesis:us-west-2:111111111111:stream/fake-stream-name',
+            'arn:aws:kinesis:us-west-2:111111111111:stream/fake-stream-name/consumer/consumer-1:1111111111',
+            self::$awsRoleArn,
+            self::$gcpServiceAccount
+        ]);
+
+        $this->assertMatchesRegularExpression('/Topic updated:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+    }
 }

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -624,4 +624,28 @@ class PubSubTest extends TestCase
         $this->assertMatchesRegularExpression('/Topic updated:/', $output);
         $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
     }
+    public function testCreateTopicWithCloudStorageIngestion()
+    {
+        $this->requireEnv('PUBSUB_EMULATOR_HOST');
+
+        $topic = 'test-topic-' . rand();
+        $output = $this->runFunctionSnippet('create_topic_with_cloud_storage_ingestion', [
+            self::$projectId,
+            $topic,
+            $this->requireEnv('GOOGLE_PUBSUB_STORAGE_BUCKET'),
+            'text',
+            '1970-01-01T00:00:00Z',
+            "\n",
+            '**.txt'
+        ]);
+        $this->assertMatchesRegularExpression('/Topic created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+
+        $output = $this->runFunctionSnippet('delete_topic', [
+            self::$projectId,
+            $topic,
+        ]);
+        $this->assertMatchesRegularExpression('/Topic deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+    }
 }

--- a/pubsub/api/test/pubsubTest.php
+++ b/pubsub/api/test/pubsubTest.php
@@ -624,6 +624,7 @@ class PubSubTest extends TestCase
         $this->assertMatchesRegularExpression('/Topic updated:/', $output);
         $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
     }
+
     public function testCreateTopicWithCloudStorageIngestion()
     {
         $this->requireEnv('PUBSUB_EMULATOR_HOST');
@@ -637,6 +638,30 @@ class PubSubTest extends TestCase
             '1970-01-01T00:00:00Z',
             "\n",
             '**.txt'
+        ]);
+        $this->assertMatchesRegularExpression('/Topic created:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+
+        $output = $this->runFunctionSnippet('delete_topic', [
+            self::$projectId,
+            $topic,
+        ]);
+        $this->assertMatchesRegularExpression('/Topic deleted:/', $output);
+        $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);
+    }
+
+    public function testCreateTopicWithAwsMskIngestion()
+    {
+        $this->requireEnv('PUBSUB_EMULATOR_HOST');
+
+        $topic = 'test-topic-' . rand();
+        $output = $this->runFunctionSnippet('create_topic_with_aws_msk_ingestion', [
+            self::$projectId,
+            $topic,
+            'arn:aws:kafka:us-east-1:111111111111:cluster/fake-cluster-name/11111111-1111-1',
+            'fake-msk-topic-name',
+            self::$awsRoleArn,
+            self::$gcpServiceAccount
         ]);
         $this->assertMatchesRegularExpression('/Topic created:/', $output);
         $this->assertMatchesRegularExpression(sprintf('/%s/', $topic), $output);

--- a/storage/src/disable_soft_delete.php
+++ b/storage/src/disable_soft_delete.php
@@ -23,33 +23,32 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_get_soft_delete_policy]
+# [START storage_disable_soft_delete]
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Gets a bucket soft delete policy.
+ * Disable bucket's soft delete.
  *
  * @param string $bucketName The name of your Cloud Storage bucket.
  *        (e.g. 'my-bucket')
  */
-function get_soft_delete_policy(string $bucketName): void
+function disable_soft_delete(string $bucketName): void
 {
-    $storage = new StorageClient();
-    $bucket = $storage->bucket($bucketName);
-    $bucket->reload();
-
-    if ($bucket->info()['softDeletePolicy']['retentionDurationSeconds'] === '0') {
+    try {
+        $storage = new StorageClient();
+        $bucket = $storage->bucket($bucketName);
+        $x = $bucket->update([
+            'softDeletePolicy' => [
+                'retentionDurationSeconds' => 0,
+            ],
+        ]);
         printf('Bucket %s soft delete policy was disabled' . PHP_EOL, $bucketName);
-    } else {
-        printf('Soft delete Policy for ' . $bucketName . PHP_EOL);
-        printf('Soft delete Period: %d seconds' . PHP_EOL, $bucket->info()['softDeletePolicy']['retentionDurationSeconds']);
-        if ($bucket->info()['softDeletePolicy']['effectiveTime']) {
-            printf('Effective Time: ' . $bucket->info()['softDeletePolicy']['effectiveTime'] . PHP_EOL);
-        }
+    } catch (\Throwable $th) {
+        print_r($th);
     }
 
 }
-# [END storage_get_soft_delete_policy]
+# [END storage_disable_soft_delete]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/get_soft_delete_policy.php
+++ b/storage/src/get_soft_delete_policy.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_get_soft_delete_policy]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Gets a bucket soft delete policy.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function get_soft_delete_policy(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $bucket->reload();
+
+    if ($bucket->info()['softDeletePolicy']['retentionDurationSeconds'] === '0') {
+        printf('Bucket %s soft delete policy was disabled' . PHP_EOL, $bucketName);    
+    } else {
+        printf('Soft delete Policy for ' . $bucketName . PHP_EOL);
+        printf('Soft delete Period: %d seconds' . PHP_EOL, $bucket->info()['softDeletePolicy']['retentionDurationSeconds']);
+        if ($bucket->info()['softDeletePolicy']['effectiveTime']) {
+            printf('Effective Time: ' . $bucket->info()['softDeletePolicy']['effectiveTime'] . PHP_EOL);
+        }
+    }
+    
+}
+# [END storage_get_soft_delete_policy]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/get_soft_delete_policy.php
+++ b/storage/src/get_soft_delete_policy.php
@@ -42,12 +42,17 @@ function get_soft_delete_policy(string $bucketName): void
         printf('Bucket %s soft delete policy was disabled' . PHP_EOL, $bucketName);
     } else {
         printf('Soft delete Policy for ' . $bucketName . PHP_EOL);
-        printf('Soft delete Period: %d seconds' . PHP_EOL, $bucket->info()['softDeletePolicy']['retentionDurationSeconds']);
+        printf(
+            'Soft delete Period: %d seconds' . PHP_EOL,
+            $bucket->info()['softDeletePolicy']['retentionDurationSeconds']
+        );
         if ($bucket->info()['softDeletePolicy']['effectiveTime']) {
-            printf('Effective Time: ' . $bucket->info()['softDeletePolicy']['effectiveTime'] . PHP_EOL);
+            printf(
+                'Effective Time: %s' . PHP_EOL,
+                $bucket->info()['softDeletePolicy']['effectiveTime']
+            );
         }
     }
-
 }
 # [END storage_get_soft_delete_policy]
 

--- a/storage/src/list_soft_deleted_object_versions.php
+++ b/storage/src/list_soft_deleted_object_versions.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_list_soft_deleted_object_versions]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * List Cloud Storage bucket soft deleted objects.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $objectName The name of your Cloud Storage object.
+ *        (e.g. 'my-object')
+ */
+function list_soft_deleted_object_versions(string $bucketName, string $objectName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $options = ['softDeleted' => true, 'matchGlob' => $objectName];
+    foreach ($bucket->objects($options) as $object) {
+        printf('Object: %s' . PHP_EOL, $object->name());
+    }
+}
+# [END storage_list_soft_deleted_object_versions]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/list_soft_deleted_objects.php
+++ b/storage/src/list_soft_deleted_objects.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_list_soft_deleted_objects]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * List Cloud Storage bucket soft deleted object versions.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function list_soft_deleted_objects(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $options = ['softDeleted' => true];
+    foreach ($bucket->objects($options) as $object) {
+        printf('Object: %s' . PHP_EOL, $object->name());
+    }
+}
+# [END storage_list_soft_deleted_objects]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/restore_soft_deleted_object.php
+++ b/storage/src/restore_soft_deleted_object.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_restore_object]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Restore softDeleted objects.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $objectName The name of your Cloud Storage object.
+ *        (e.g. 'my-object')
+ * @param string $generation The generation of the bucket to restore.
+ *        (e.g. '123456789')
+ */
+function restore_soft_deleted_object(string $bucketName, string $objectName, string $generation): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $bucket->restore($objectName, $generation);
+
+    printf('Soft deleted object %s was restored.' . PHP_EOL, $objectName);
+}
+# [END storage_restore_object]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/set_soft_delete_policy.php
+++ b/storage/src/set_soft_delete_policy.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_set_soft_delete_policy]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Sets a bucket's soft delete policy.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function set_soft_delete_policy(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $bucket->update([
+        'softDeletePolicy' => [
+            'retentionDurationSeconds' => 864000,
+        ],
+    ]);
+    printf('Bucket %s soft delete policy set to 10 days' . PHP_EOL, $bucketName);
+}
+# [END storage_set_soft_delete_policy]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -410,4 +410,24 @@ EOF;
         $this->assertStringNotContainsString('Custom Time', $output);
         $this->assertStringNotContainsString('Retention Expiration Time', $output);
     }
+
+    public function testListSoftDeletedObjects()
+    {
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $bucket->update([
+            'softDeletePolicy' => [
+                'retentionDuration' => '604800s',
+            ],
+        ]);
+
+        $objectName = uniqid('soft-deleted-object-');
+        $object = $bucket->upload('content', ['name' => $objectName]);
+        $object->delete();
+
+        $output = self::runFunctionSnippet('list_soft_deleted_objects', [
+            self::$bucketName,
+        ]);
+        
+        $this->assertStringContainsString('Object:', $output);
+    }
 }

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -427,7 +427,7 @@ EOF;
         $output = self::runFunctionSnippet('list_soft_deleted_objects', [
             self::$bucketName,
         ]);
-        
+
         $this->assertStringContainsString('Object:', $output);
     }
 
@@ -452,7 +452,7 @@ EOF;
             self::$bucketName,
             $objectName1
         ]);
-        
+
         $this->assertStringContainsString($objectName1, $output);
         $this->assertStringNotContainsString($objectName2, $output);
     }

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -430,4 +430,30 @@ EOF;
         
         $this->assertStringContainsString('Object:', $output);
     }
+
+    public function testListSoftDeletedObjectVersions()
+    {
+        $bucket = self::$storage->bucket(self::$bucketName);
+        $bucket->update([
+            'softDeletePolicy' => [
+                'retentionDuration' => '604800s',
+            ],
+        ]);
+
+        $objectName1 = 'soft-deleted-object-1';
+        $object1 = $bucket->upload('content', ['name' => $objectName1]);
+        $object1->delete();
+
+        $objectName2 = 'soft-deleted-object-2';
+        $object2 = $bucket->upload('content', ['name' => $objectName2]);
+        $object2->delete();
+
+        $output = self::runFunctionSnippet('list_soft_deleted_object_versions', [
+            self::$bucketName,
+            $objectName1
+        ]);
+        
+        $this->assertStringContainsString($objectName1, $output);
+        $this->assertStringNotContainsString($objectName2, $output);
+    }
 }

--- a/storage/test/ObjectsTest.php
+++ b/storage/test/ObjectsTest.php
@@ -416,7 +416,7 @@ EOF;
         $bucket = self::$storage->bucket(self::$bucketName);
         $bucket->update([
             'softDeletePolicy' => [
-                'retentionDuration' => '604800s',
+                'retentionDuration' => 604800,
             ],
         ]);
 
@@ -436,7 +436,7 @@ EOF;
         $bucket = self::$storage->bucket(self::$bucketName);
         $bucket->update([
             'softDeletePolicy' => [
-                'retentionDuration' => '604800s',
+                'retentionDuration' => 604800,
             ],
         ]);
 
@@ -462,7 +462,7 @@ EOF;
         $bucket = self::$storage->bucket(self::$bucketName);
         $bucket->update([
             'softDeletePolicy' => [
-                'retentionDuration' => '60s',
+                'retentionDuration' => 60,
             ],
         ]);
 

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -969,6 +969,39 @@ class storageTest extends TestCase
         );
     }
 
+    public function testGetSoftDeletePolicy()
+    {
+        $bucketName = uniqid('samples-get-soft-delete-policy-');
+        $bucket = self::$storage->createBucket($bucketName, [
+            'softDeletePolicy' => [
+                'retentionDurationSeconds' => 604800,
+            ],
+        ]);
+
+        $output = self::runFunctionSnippet('get_soft_delete_policy', [
+            $bucketName,
+        ]);
+        $info = $bucket->info();
+        $bucket->delete();
+
+        if ($info['softDeletePolicy']['retentionDurationSeconds'] === '0') {
+            $this->assertStringContainsString(
+                sprintf('Bucket %s soft delete policy was disabled', $bucketName),
+                $output
+            );  
+        } else {
+            $duration = $info['softDeletePolicy']['retentionDurationSeconds'];
+            $effectiveTime = $info['softDeletePolicy']['effectiveTime'];
+            $outputString = <<<EOF
+                Soft delete Policy for $bucketName
+                Soft delete Period: $duration seconds
+                Effective Time: $effectiveTime
+
+                EOF;
+            $this->assertEquals($output, $outputString);
+        }
+    }
+
     public function testDeleteFileArchivedGeneration()
     {
         $bucket = self::$storage->createBucket(uniqid('samples-delete-file-archived-generation-'), [

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -988,7 +988,7 @@ class storageTest extends TestCase
             $this->assertStringContainsString(
                 sprintf('Bucket %s soft delete policy was disabled', $bucketName),
                 $output
-            );  
+            );
         } else {
             $duration = $info['softDeletePolicy']['retentionDurationSeconds'];
             $effectiveTime = $info['softDeletePolicy']['effectiveTime'];
@@ -1019,6 +1019,34 @@ class storageTest extends TestCase
         $this->assertStringContainsString(
             sprintf(
                 'Bucket %s soft delete policy set to 10 days',
+                $bucketName
+            ),
+            $output
+        );
+    }
+
+    public function testDisableSoftDelete()
+    {
+        $bucketName = uniqid('samples-disable-soft-delete-');
+        $bucket = self::$storage->createBucket($bucketName, [
+            'softDeletePolicy' => [
+                'retentionDurationSeconds' => 604800,
+            ],
+        ]);
+        $info = $bucket->reload();
+
+        $this->assertEquals('604800', $info['softDeletePolicy']['retentionDurationSeconds']);
+
+        $output = self::runFunctionSnippet('disable_soft_delete', [
+            $bucketName
+        ]);
+        $info = $bucket->reload();
+        $this->assertEquals('0', $info['softDeletePolicy']['retentionDurationSeconds']);
+        $bucket->delete();
+
+        $this->assertStringContainsString(
+            sprintf(
+                'Bucket %s soft delete policy was disabled',
                 $bucketName
             ),
             $output

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -1002,6 +1002,29 @@ class storageTest extends TestCase
         }
     }
 
+    public function testSetSoftDeletePolicy()
+    {
+        $bucketName = uniqid('samples-set-soft-delete-policy-');
+        $bucket = self::$storage->createBucket($bucketName);
+        $info = $bucket->reload();
+
+        $this->assertNotEquals('864000', $info['softDeletePolicy']['retentionDurationSeconds']);
+        $output = self::runFunctionSnippet('set_soft_delete_policy', [
+            $bucketName
+        ]);
+        $info = $bucket->reload();
+        $this->assertEquals('864000', $info['softDeletePolicy']['retentionDurationSeconds']);
+        $bucket->delete();
+
+        $this->assertStringContainsString(
+            sprintf(
+                'Bucket %s soft delete policy set to 10 days',
+                $bucketName
+            ),
+            $output
+        );
+    }
+
     public function testDeleteFileArchivedGeneration()
     {
         $bucket = self::$storage->createBucket(uniqid('samples-delete-file-archived-generation-'), [

--- a/storagebatchoperations/README.md
+++ b/storagebatchoperations/README.md
@@ -1,0 +1,61 @@
+# Google Cloud Storage Batch Operations Samples
+
+## Description
+
+All code in the snippets directory demonstrates how to invoke
+[Cloud Storage Batch Operations][google-cloud-php-storage-batch-operations] from PHP.
+
+[cloud-storage-batch-operations]: https://cloud.google.com/storage/docs/batch-operations/overview
+
+## Setup:
+
+1.  **Enable APIs** - [Enable the Storage Batch Operations Service API](https://console.cloud.google.com/flows/enableapi?apiid=storage.googleapis.com)
+    and create a new project or select an existing project.
+2.  **Download The Credentials** - Click "Go to credentials" after enabling the APIs. Click "New Credentials"
+    and select "Service Account Key". Create a new service account, use the JSON key type, and
+    select "Create". Once downloaded, set the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+    to the path of the JSON key that was downloaded.
+3.  **Clone the repo** and cd into this directory
+
+    ```sh
+    $ git clone https://github.com/GoogleCloudPlatform/php-docs-samples
+    $ cd php-docs-samples/storagebatchoperations
+    ```
+4.  **Install dependencies** via [Composer](http://getcomposer.org/doc/00-intro.md).
+    Run `php composer.phar install` (if composer is installed locally) or `composer install`
+    (if composer is installed globally).
+
+
+## Samples
+
+To run the Storage Batch Operations Samples, run any of the files in `src/` on the CLI:
+
+```
+$ php src/create_job.php
+
+Usage: create_job.php $jobId $bucketName $objectPrefix
+
+  @param string $projectId The Project ID
+  @param string $jobId The new Job ID
+  @param string $bucketName The Storage bucket name
+  @param string $objectPrefix The Object prefix
+```
+
+## The client library
+
+This sample uses the [Cloud Storage Batch Operations Client Library for PHP][google-cloud-php-storage-batch-operations].
+You can read the documentation for more details on API usage and use GitHub
+to [browse the source][google-cloud-php-source] and  [report issues][google-cloud-php-issues].
+
+[google-cloud-php-storage-batch-operations]: https://cloud.google.com/php/docs/reference/cloud-storagebatchoperations/latest
+[google-cloud-php-source]: https://github.com/GoogleCloudPlatform/google-cloud-php
+[google-cloud-php-issues]: https://github.com/GoogleCloudPlatform/google-cloud-php/issues
+[google-cloud-sdk]: https://cloud.google.com/sdk/
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](../../LICENSE)

--- a/storagebatchoperations/composer.json
+++ b/storagebatchoperations/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "google/cloud-storagebatchoperations": "0.1.1"
+    },
+    "require-dev": {
+        "google/cloud-storage": "^1.48.1"
+    }
+}

--- a/storagebatchoperations/phpunit.xml.dist
+++ b/storagebatchoperations/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../testing/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP storagebatchoperations test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
+</phpunit>

--- a/storagebatchoperations/src/cancel_job.php
+++ b/storagebatchoperations/src/cancel_job.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagebatchoperations/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+# [START storage_batch_cancel_job]
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\CancelJobRequest;
+
+/**
+ * Cancel a batch job.
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *        (e.g. 'my-project-id')
+ * @param string $jobId A unique identifier for this job.
+ *        (e.g. '94d60cc1-2d95-41c5-b6e3-ff66cd3532d5')
+ */
+function cancel_job(string $projectId, string $jobId): void
+{
+    // Create a client.
+    $storageBatchOperationsClient = new StorageBatchOperationsClient();
+
+    $parent = $storageBatchOperationsClient->locationName($projectId, 'global');
+    $formattedName = $parent . '/jobs/' . $jobId;
+
+    $request = new CancelJobRequest([
+        'name' => $formattedName,
+    ]);
+
+    $storageBatchOperationsClient->cancelJob($request);
+
+    printf('Cancelled job: %s', $formattedName);
+}
+# [END storage_batch_cancel_job]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagebatchoperations/src/create_job.php
+++ b/storagebatchoperations/src/create_job.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagebatchoperations/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+# [START storage_batch_create_job]
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\CreateJobRequest;
+use Google\Cloud\StorageBatchOperations\V1\Job;
+use Google\Cloud\StorageBatchOperations\V1\BucketList;
+use Google\Cloud\StorageBatchOperations\V1\BucketList\Bucket;
+use Google\Cloud\StorageBatchOperations\V1\PrefixList;
+use Google\Cloud\StorageBatchOperations\V1\DeleteObject;
+
+/**
+ * Create a new batch job.
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *        (e.g. 'my-project-id')
+ * @param string $jobId A unique identifier for this job.
+ *        (e.g. '94d60cc1-2d95-41c5-b6e3-ff66cd3532d5')
+ * @param string $bucketName The name of your Cloud Storage bucket to operate on.
+ *        (e.g. 'my-bucket')
+ * @param string $objectPrefix The prefix of objects to include in the operation.
+ *        (e.g. 'prefix1')
+ */
+function create_job(string $projectId, string $jobId, string $bucketName, string $objectPrefix): void
+{
+    // Create a client.
+    $storageBatchOperationsClient = new StorageBatchOperationsClient();
+
+    $parent = $storageBatchOperationsClient->locationName($projectId, 'global');
+
+    $prefixListConfig = new PrefixList(['included_object_prefixes' => [$objectPrefix]]);
+    $bucket = new Bucket(['bucket' => $bucketName, 'prefix_list' => $prefixListConfig]);
+    $bucketList = new BucketList(['buckets' => [$bucket]]);
+
+    $deleteObject = new DeleteObject(['permanent_object_deletion_enabled' => false]);
+
+    $job = new Job(['bucket_list' => $bucketList, 'delete_object' => $deleteObject]);
+
+    $request = new CreateJobRequest([
+        'parent' => $parent,
+        'job_id' => $jobId,
+        'job' => $job,
+    ]);
+    $response = $storageBatchOperationsClient->createJob($request);
+
+    printf('Created job: %s', $response->getName());
+}
+# [END storage_batch_create_job]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagebatchoperations/src/delete_job.php
+++ b/storagebatchoperations/src/delete_job.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagebatchoperations/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+# [START storage_batch_delete_job]
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\DeleteJobRequest;
+
+/**
+ * Delete a batch job.
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *        (e.g. 'my-project-id')
+ * @param string $jobId A unique identifier for this job.
+ *        (e.g. '94d60cc1-2d95-41c5-b6e3-ff66cd3532d5')
+ */
+function delete_job(string $projectId, string $jobId): void
+{
+    // Create a client.
+    $storageBatchOperationsClient = new StorageBatchOperationsClient();
+
+    $parent = $storageBatchOperationsClient->locationName($projectId, 'global');
+    $formattedName = $parent . '/jobs/' . $jobId;
+
+    $request = new DeleteJobRequest([
+        'name' => $formattedName,
+    ]);
+
+    $storageBatchOperationsClient->deleteJob($request);
+
+    printf('Deleted job: %s', $formattedName);
+}
+# [END storage_batch_delete_job]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagebatchoperations/src/get_job.php
+++ b/storagebatchoperations/src/get_job.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagebatchoperations/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+# [START storage_batch_get_job]
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\GetJobRequest;
+
+/**
+ * Gets a batch job.
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *        (e.g. 'my-project-id')
+ * @param string $jobId A unique identifier for this job.
+ *        (e.g. '94d60cc1-2d95-41c5-b6e3-ff66cd3532d5')
+ */
+function get_job(string $projectId, string $jobId): void
+{
+    // Create a client.
+    $storageBatchOperationsClient = new StorageBatchOperationsClient();
+
+    $parent = $storageBatchOperationsClient->locationName($projectId, 'global');
+    $formattedName = $parent . '/jobs/' . $jobId;
+
+    $request = new GetJobRequest([
+        'name' => $formattedName,
+    ]);
+
+    $response = $storageBatchOperationsClient->getJob($request);
+
+    printf('Got job: %s', $response->getName());
+}
+# [END storage_batch_get_job]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagebatchoperations/src/list_jobs.php
+++ b/storagebatchoperations/src/list_jobs.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagebatchoperations/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+# [START storage_batch_list_jobs]
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\ListJobsRequest;
+
+/**
+ * List Jobs in a given project.
+ *
+ * @param string $projectId Your Google Cloud project ID.
+ *        (e.g. 'my-project-id')
+ */
+function list_jobs(string $projectId): void
+{
+    // Create a client.
+    $storageBatchOperationsClient = new StorageBatchOperationsClient();
+
+    $parent = $storageBatchOperationsClient->locationName($projectId, 'global');
+
+    $request = new ListJobsRequest([
+        'parent' => $parent,
+    ]);
+
+    $jobs = $storageBatchOperationsClient->listJobs($request);
+
+    foreach ($jobs as $job) {
+        printf('Job name: %s' . PHP_EOL, $job->getName());
+    }
+}
+# [END storage_batch_list_jobs]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagebatchoperations/test/StorageBatchOperationsTest.php
+++ b/storagebatchoperations/test/StorageBatchOperationsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Samples\StorageBatchOperations;
+
+use Google\Cloud\StorageBatchOperations\V1\Client\StorageBatchOperationsClient;
+use Google\Cloud\StorageBatchOperations\V1\GetJobRequest;
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for storage batch operations library samples.
+ */
+class StorageBatchOperationsTest extends TestCase
+{
+    use TestTrait;
+
+    private static $bucket;
+    private static $jobId;
+    private static $jobName;
+    private static $parent;
+    private static $storage;
+    private static $objectPrefix;
+    private static $storageBatchOperationsClient;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::checkProjectEnvVars();
+        self::$storage = new StorageClient();
+        $uniqueBucketId = time() . rand();
+        self::$storageBatchOperationsClient = new StorageBatchOperationsClient();
+        self::$jobId = time() . rand();
+        self::$objectPrefix = 'dummy';
+
+        self::$parent = self::$storageBatchOperationsClient->locationName(self::$projectId, 'global');
+        self::$jobName = self::$parent . '/jobs/' . self::$jobId;
+
+        self::$bucket = self::$storage->createBucket(sprintf('php-gcs-sbo-sample-%s', $uniqueBucketId));
+
+        $objectName = self::$objectPrefix . '-object-1.txt';
+        self::$bucket->upload('test content', ['name' => $objectName]);
+
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$bucket->objects(['versions' => true]) as $object) {
+            $object->delete();
+        }
+        self::$bucket->delete();
+    }
+
+    public function testCreateJob()
+    {
+        $output = $this->runFunctionSnippet('create_job', [
+            self::$projectId, self::$jobId, self::$bucket->name(), self::$objectPrefix
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Created job: %s', self::$parent),
+            $output
+        );
+    }
+
+    /**
+     * @depends testCreateJob
+     */
+    public function testGetJob()
+    {
+        $output = $this->runFunctionSnippet('get_job', [
+            self::$projectId, self::$jobId
+        ]);
+
+        $this->assertStringContainsString(
+            self::$jobName,
+            $output
+        );
+    }
+
+    /**
+     * @depends testGetJob
+     */
+    public function testListJobs()
+    {
+        $output = $this->runFunctionSnippet('list_jobs', [
+            self::$projectId
+        ]);
+
+        $this->assertStringContainsString(
+            self::$jobName,
+            $output
+        );
+    }
+
+    /**
+     * @depends testListJobs
+     */
+    public function testCancelJob()
+    {
+        $output = $this->runFunctionSnippet('cancel_job', [
+            self::$projectId, self::$jobId
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Cancelled job: %s', self::$jobName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testCancelJob
+     */
+    public function testDeleteJob()
+    {
+        $attempt = 0;
+        $maxAttempts = 10;
+        $jobReadyForDeletion = false;
+        while ($attempt < $maxAttempts && !$jobReadyForDeletion) {
+            $attempt++;
+            $request = new GetJobRequest([
+                'name' => self::$jobName,
+            ]);
+
+            $response = self::$storageBatchOperationsClient->getJob($request);
+            $state = $response->getState();
+            $status = \Google\Cloud\StorageBatchOperations\V1\Job\State::name($state);
+
+            // A job is typically deletable if it's not in a creating/pending/running state
+            // Consider PENDING or IN_PROGRESS as states to wait out.
+            // For immediate deletion, maybe it needs to be SUCCEEDED or FAILED or CANCELED.
+            if ($status !== 'STATE_UNSPECIFIED' && $status !== 'RUNNING') {
+                $jobReadyForDeletion = true;
+            }
+
+            if (!$jobReadyForDeletion && $attempt < $maxAttempts) {
+                sleep(10);   // Wait 10 seconds
+            }
+        }
+
+        if (!$jobReadyForDeletion) {
+            $this->fail('Job did not reach a deletable state within the allowed time.');
+        }
+
+        // Now attempt to delete the job
+        $output = $this->runFunctionSnippet('delete_job', [
+            self::$projectId, self::$jobId
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Deleted job: %s', self::$jobName),
+            $output
+        );
+    }
+}


### PR DESCRIPTION
This internal PR implements sample code for object-level soft delete, enabling users to:

- List soft-deleted objects
- List versions of soft-deleted objects
- Restore deleted objects
- Disable soft-delete
- Get soft-delete policy
- Set soft-delete policy