### PR TITLE
Feat(StorageControl): Add sample for anywhereCache

### DIFF
--- a/secretmanager/composer.json
+++ b/secretmanager/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "google/cloud-secret-manager": "^2.0.0"
+        "google/cloud-secret-manager": "^2.1.0",
+        "google/cloud-resource-manager": "^1.0"
     }
 }

--- a/secretmanager/src/bind_tags_to_regional_secret.php
+++ b/secretmanager/src/bind_tags_to_regional_secret.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_bind_tags_to_regional_secret]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\ResourceManager\V3\Client\TagBindingsClient;
+use Google\Cloud\ResourceManager\V3\CreateTagBindingRequest;
+use Google\Cloud\ResourceManager\V3\TagBinding;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $tagValue   Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function bind_tags_to_regional_secret(string $projectId, string $locationId, string $secretId, string $tagValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s' . PHP_EOL, $newSecret->getName());
+
+    // Specify regional endpoint.
+    $tagBindOptions = ['apiEndpoint' => "$locationId-cloudresourcemanager.googleapis.com"];
+    $tagBindingsClient = new TagBindingsClient($tagBindOptions);
+    $tagBinding = (new TagBinding())
+        ->setParent('//secretmanager.googleapis.com/' . $newSecret->getName())
+        ->setTagValue($tagValue);
+
+    // Build the request.
+    $request = (new CreateTagBindingRequest())
+        ->setTagBinding($tagBinding);
+
+    // Create the tag binding.
+    $operationResponse = $tagBindingsClient->createTagBinding($request);
+    $operationResponse->pollUntilComplete();
+
+    // Check if the operation succeeded.
+    if ($operationResponse->operationSucceeded()) {
+        printf('Tag binding created for secret %s with tag value %s' . PHP_EOL, $newSecret->getName(), $tagValue);
+    } else {
+        $error = $operationResponse->getError();
+        printf('Error in creating tag binding: %s' . PHP_EOL, $error->getMessage());
+    }
+}
+// [END secretmanager_bind_tags_to_regional_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/bind_tags_to_secret.php
+++ b/secretmanager/src/bind_tags_to_secret.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_bind_tags_to_secret]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\ResourceManager\V3\Client\TagBindingsClient;
+use Google\Cloud\ResourceManager\V3\CreateTagBindingRequest;
+use Google\Cloud\ResourceManager\V3\TagBinding;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ * @param string $tagValue  Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function bind_tags_to_secret(string $projectId, string $secretId, string $tagValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s' . PHP_EOL, $newSecret->getName());
+
+    $tagBindingsClient = new TagBindingsClient();
+    $tagBinding = (new TagBinding())
+        ->setParent('//secretmanager.googleapis.com/' . $newSecret->getName())
+        ->setTagValue($tagValue);
+
+    // Build the binding request.
+    $request = (new CreateTagBindingRequest())
+        ->setTagBinding($tagBinding);
+
+    // Create the tag binding.
+    $operationResponse = $tagBindingsClient->createTagBinding($request);
+    $operationResponse->pollUntilComplete();
+
+    // Check if the operation succeeded.
+    if ($operationResponse->operationSucceeded()) {
+        printf('Tag binding created for secret %s with tag value %s' . PHP_EOL, $newSecret->getName(), $tagValue);
+    } else {
+        $error = $operationResponse->getError();
+        printf('Error in creating tag binding: %s' . PHP_EOL, $error->getMessage());
+    }
+}
+// [END secretmanager_bind_tags_to_secret]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_regional_secret_with_annotations.php
+++ b/secretmanager/src/create_regional_secret_with_annotations.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_regional_secret_with_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId       Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId      Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId        Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey   Your annotation key (e.g. 'annotation-key')
+ * @param string $annotationValue Your annotation value (e.g. 'annotation-value')
+ */
+function create_regional_secret_with_annotations(string $projectId, string $locationId, string $secretId, string $annotationKey, string $annotationValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+
+    // set the annotations.
+    $annotations = [$annotationKey => $annotationValue];
+    $secret->setAnnotations($annotations);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with annotations', $newSecret->getName());
+}
+// [END secretmanager_create_regional_secret_with_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_regional_secret_with_labels.php
+++ b/secretmanager/src/create_regional_secret_with_labels.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_regional_secret_with_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey   Your label key (e.g. 'label-key')
+ * @param string $labelValue Your label value (e.g. 'label-value')
+ */
+function create_regional_secret_with_labels(string $projectId, string $locationId, string $secretId, string $labelKey, string $labelValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+
+    // set the labels.
+    $labels = [$labelKey => $labelValue];
+    $secret->setLabels($labels);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with labels', $newSecret->getName());
+}
+// [END secretmanager_create_regional_secret_with_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_regional_secret_with_tags.php
+++ b/secretmanager/src/create_regional_secret_with_tags.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_regional_create_secret_with_tags]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your Google Cloud Location ID (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $tagKey     Your tag key (e.g. 'tagKeys/281475012216835')
+ * @param string $tagValue   Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function create_regional_secret_with_tags(string $projectId, string $locationId, string $secretId, string $tagKey, string $tagValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the parent project.
+    $parent = $client->locationName($projectId, $locationId);
+
+    $secret = new Secret();
+
+    // set the tags.
+    $tags = [$tagKey => $tagValue];
+    $secret ->setTags($tags);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with tag', $newSecret->getName());
+}
+// [END secretmanager_regional_create_secret_with_tags]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_secret_with_annotations.php
+++ b/secretmanager/src/create_secret_with_annotations.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_secret_with_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId       Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId        Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey   Your annotation key (e.g. 'annotation-key')
+ * @param string $annotationValue Your annotation value (e.g. 'annotation-value')
+ */
+function create_secret_with_annotations(string $projectId, string $secretId, string $annotationKey, string $annotationValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+
+    // set the annoation.
+    $annotation = [$annotationKey => $annotationValue];
+    $secret->setAnnotations($annotation);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with annotations', $newSecret->getName());
+}
+// [END secretmanager_create_secret_with_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_secret_with_labels.php
+++ b/secretmanager/src/create_secret_with_labels.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_secret_with_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey   Your label key (e.g. 'label-key')
+ * @param string $labelValue Your label value (e.g. 'label-value')
+ */
+function create_secret_with_labels(string $projectId, string $secretId, string $labelKey, string $labelValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+
+    // set the labels.
+    $labels = [$labelKey => $labelValue];
+    $secret->setLabels($labels);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with labels', $newSecret->getName());
+}
+// [END secretmanager_create_secret_with_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/create_secret_with_tags.php
+++ b/secretmanager/src/create_secret_with_tags.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_create_secret_with_tags]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\CreateSecretRequest;
+use Google\Cloud\SecretManager\V1\Replication;
+use Google\Cloud\SecretManager\V1\Replication\Automatic;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ * @param string $tagKey    Your tag key (e.g. 'tagKeys/281475012216835')
+ * @param string $tagValue  Your tag value (e.g. 'tagValues/281476592621530')
+ */
+function create_secret_with_tags(string $projectId, string $secretId, string $tagKey, string $tagValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $parent = $client->projectName($projectId);
+
+    $secret = new Secret([
+        'replication' => new Replication([
+            'automatic' => new Automatic(),
+        ]),
+    ]);
+
+    // set the tags.
+    $tags = [$tagKey => $tagValue];
+    $secret->setTags($tags);
+
+    // Build the request.
+    $request = CreateSecretRequest::build($parent, $secretId, $secret);
+
+    // Create the secret.
+    $newSecret = $client->createSecret($request);
+
+    // Print the new secret name.
+    printf('Created secret %s with tag', $newSecret->getName());
+}
+// [END secretmanager_create_secret_with_tags]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/delete_regional_secret_annotation.php
+++ b/secretmanager/src/delete_regional_secret_annotation.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_delete_regional_secret_annotation]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId     Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId    Your secret Location (e.g. 'us-central1')
+ * @param string $secretId      Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey Your annotation key (e.g. 'annotation-key')
+ */
+function delete_regional_secret_annotation(string $projectId, string $locationId, string $secretId, string $annotationKey): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // delete the annotation
+    unset($annotations[$annotationKey]);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['annotations']);
+
+    // build the secret
+    $secret = new Secret();
+    $secret->setAnnotations($annotations);
+    $secret->setName($getSecret->getName());
+
+    // build the request
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the secret name
+    printf('Updated secret %s' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_delete_regional_secret_annotation]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/delete_regional_secret_label.php
+++ b/secretmanager/src/delete_regional_secret_label.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_delete_regional_secret_label]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your secret Location (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey   Your label key (e.g. 'label-key')
+ */
+function delete_regional_secret_label(string $projectId, string $locationId, string $secretId, string $labelKey): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // delete the label
+    unset($labels[$labelKey]);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['labels']);
+
+    // build the secret
+    $secret = new Secret();
+    $secret->setLabels($labels);
+    $secret->setName($getSecret->getName());
+
+    // build the request
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the secret name
+    printf('Updated secret %s' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_delete_regional_secret_label]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/delete_secret_annotation.php
+++ b/secretmanager/src/delete_secret_annotation.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_delete_secret_annotation]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId     Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId      Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey Your annotation key (e.g. 'annotation-key')
+ */
+function delete_secret_annotation(string $projectId, string $secretId, string $annotationKey): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // delete the annotation
+    unset($annotations[$annotationKey]);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['annotations']);
+
+    // build the secret
+    $secret = new Secret();
+    $secret->setAnnotations($annotations);
+    $secret->setName($getSecret->getName());
+
+    // build the request
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the secret name
+    printf('Updated secret %s' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_delete_secret_annotation]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/delete_secret_label.php
+++ b/secretmanager/src/delete_secret_label.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_delete_secret_label]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\Secret;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey  Your label key (e.g. 'label-key')
+ */
+function delete_secret_label(string $projectId, string $secretId, string $labelKey): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // delete the label
+    unset($labels[$labelKey]);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['labels']);
+
+    // build the secret
+    $secret = new Secret();
+    $secret->setLabels($labels);
+    $secret->setName($getSecret->getName());
+
+    // build the request
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the secret name
+    printf('Updated secret %s' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_delete_secret_label]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/edit_regional_secret_annotations.php
+++ b/secretmanager/src/edit_regional_secret_annotations.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_edit_regional_secret_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId       Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId      Your secret Location (e.g. 'us-central1')
+ * @param string $secretId        Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey   Your annotation key (e.g. 'annotation-key')
+ * @param string $annotationValue Your annotation value (e.g. 'annotation-value')
+ */
+function edit_regional_secret_annotations(string $projectId, string $locationId, string $secretId, string $annotationKey, string $annotationValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // update the annotation - need to create a new annotations map with the updated values
+    $newAnnotations = [];
+    foreach ($annotations as $key => $value) {
+        $newAnnotations[$key] = $value;
+    }
+    $newAnnotations[$annotationKey] = $annotationValue;
+    $getSecret->setAnnotations($newAnnotations);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['annotations']);
+
+    // build the secret
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the updated secret
+    printf('Updated secret %s annotations' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_edit_regional_secret_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/edit_regional_secret_labels.php
+++ b/secretmanager/src/edit_regional_secret_labels.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_edit_regional_secret_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your secret Location (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey   Your label key (e.g. 'label-key')
+ * @param string $labelValue Your label value (e.g. 'label-value')
+ */
+function edit_regional_secret_labels(string $projectId, string $locationId, string $secretId, string $labelKey, string $labelValue): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // update the label - need to create a new labels map with the updated values
+    $newLabels = [];
+    foreach ($labels as $key => $value) {
+        $newLabels[$key] = $value;
+    }
+    $newLabels[$labelKey] = $labelValue;
+    $getSecret->setLabels($newLabels);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['labels']);
+
+    // build the secret
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the updated secret
+    printf('Updated secret %s labels' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_edit_regional_secret_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/edit_secret_annotations.php
+++ b/secretmanager/src/edit_secret_annotations.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_edit_secret_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId       Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId        Your secret ID (e.g. 'my-secret')
+ * @param string $annotationKey   Your annotation key (e.g. 'annotation-key')
+ * @param string $annotationValue Your annotation value (e.g. 'annotation-value')
+ */
+function edit_secret_annotations(string $projectId, string $secretId, string $annotationKey, string $annotationValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // update the annotation - need to create a new annotations map with the updated values
+    $newAnnotations = [];
+    foreach ($annotations as $key => $value) {
+        $newAnnotations[$key] = $value;
+    }
+    $newAnnotations[$annotationKey] = $annotationValue;
+    $getSecret->setAnnotations($newAnnotations);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['annotations']);
+
+    // build the secret
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the updated secret
+    printf('Updated secret %s annotations' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_edit_secret_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/edit_secret_labels.php
+++ b/secretmanager/src/edit_secret_labels.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_edit_secret_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+use Google\Cloud\SecretManager\V1\UpdateSecretRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ * @param string $labelKey   Your label key (e.g. 'label-key')
+ * @param string $labelValue Your label value (e.g. 'label-value')
+ */
+function edit_secret_labels(string $projectId, string $secretId, string $labelKey, string $labelValue): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // update the label - need to create a new labels map with the updated values
+    $newLabels = [];
+    foreach ($labels as $key => $value) {
+        $newLabels[$key] = $value;
+    }
+    $newLabels[$labelKey] = $labelValue;
+    $getSecret->setLabels($newLabels);
+
+    // set the field mask
+    $fieldMask = new FieldMask();
+    $fieldMask->setPaths(['labels']);
+
+    // build the secret
+    $request = new UpdateSecretRequest();
+    $request->setSecret($getSecret);
+    $request->setUpdateMask($fieldMask);
+
+    // update the secret
+    $updateSecret = $client->updateSecret($request);
+
+    // print the updated secret
+    printf('Updated secret %s labels' . PHP_EOL, $updateSecret->getName());
+}
+// [END secretmanager_edit_secret_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/view_regional_secret_annotations.php
+++ b/secretmanager/src/view_regional_secret_annotations.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_view_regional_secret_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your secret Location (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ */
+function view_regional_secret_annotations(string $projectId, string $locationId, string $secretId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // print the secret name
+    printf('Get secret %s with annotation:' . PHP_EOL, $getSecret->getName());
+    // we can even loop over all the annotations
+    foreach ($annotations as $key => $val) {
+        printf("\t$key: $val" . PHP_EOL);
+    }
+}
+// [END secretmanager_view_regional_secret_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/view_regional_secret_labels.php
+++ b/secretmanager/src/view_regional_secret_labels.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_view_regional_secret_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+
+/**
+ * @param string $projectId  Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $locationId Your secret Location (e.g. 'us-central1')
+ * @param string $secretId   Your secret ID (e.g. 'my-secret')
+ */
+function view_regional_secret_labels(string $projectId, string $locationId, string $secretId): void
+{
+    // Specify regional endpoint.
+    $options = ['apiEndpoint' => "secretmanager.$locationId.rep.googleapis.com"];
+
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient($options);
+
+    // Build the resource name of the secret.
+    $name = $client->projectLocationSecretName($projectId, $locationId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // print the secret name
+    printf('Get secret %s with labels:' . PHP_EOL, $getSecret->getName());
+    // we can even loop over all the labels
+    foreach ($labels as $key => $val) {
+        printf("\t$key: $val" . PHP_EOL);
+    }
+}
+// [END secretmanager_view_regional_secret_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/view_secret_annotations.php
+++ b/secretmanager/src/view_secret_annotations.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_view_secret_annotations]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ */
+function view_secret_annotations(string $projectId, string $secretId): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the annotations
+    $annotations = $getSecret->getAnnotations();
+
+    // print the secret name
+    printf('Get secret %s with annotation:' . PHP_EOL, $getSecret->getName());
+    // we can even loop over all the annotations
+    foreach ($annotations as $key => $val) {
+        printf("\t$key: $val" . PHP_EOL);
+    }
+}
+// [END secretmanager_view_secret_annotations]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/src/view_secret_labels.php
+++ b/secretmanager/src/view_secret_labels.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/secretmanager/README.md
+ */
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\SecretManager;
+
+// [START secretmanager_view_secret_labels]
+// Import the Secret Manager client library.
+use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
+use Google\Cloud\SecretManager\V1\GetSecretRequest;
+
+/**
+ * @param string $projectId Your Google Cloud Project ID (e.g. 'my-project')
+ * @param string $secretId  Your secret ID (e.g. 'my-secret')
+ */
+function view_secret_labels(string $projectId, string $secretId): void
+{
+    // Create the Secret Manager client.
+    $client = new SecretManagerServiceClient();
+
+    // Build the resource name of the parent project.
+    $name = $client->secretName($projectId, $secretId);
+
+    // Build the request.
+    $request = GetSecretRequest::build($name);
+
+    // get the secret.
+    $getSecret = $client->getSecret($request);
+
+    // get the secret labels
+    $labels = $getSecret->getLabels();
+
+    // print the secret name
+    printf('Get secret %s with labels:' . PHP_EOL, $getSecret->getName());
+    // we can even loop over all the labels
+    foreach ($labels as $key => $val) {
+        printf("\t$key: $val" . PHP_EOL);
+    }
+}
+// [END secretmanager_view_secret_labels]
+
+// The following 2 lines are only needed to execute the samples on the CLI
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/secretmanager/test/regionalsecretmanagerTest.php
+++ b/secretmanager/test/regionalsecretmanagerTest.php
@@ -57,9 +57,17 @@ class regionalsecretmanagerTest extends TestCase
     private static $testSecretVersionToEnable;
     private static $testSecretWithTagToCreateName;
     private static $testSecretBindTagToCreateName;
+    private static $testSecretWithLabelsToCreateName;
+    private static $testSecretWithAnnotationsToCreateName;
 
     private static $iamUser = 'user:kapishsingh@google.com';
     private static $locationId = 'us-central1';
+    private static $testLabelKey = 'test-label-key';
+    private static $testLabelValue = 'test-label-value';
+    private static $testUpdatedLabelValue = 'test-label-new-value';
+    private static $testAnnotationKey = 'test-annotation-key';
+    private static $testAnnotationValue = 'test-annotation-value';
+    private static $testUpdatedAnnotationValue = 'test-annotation-new-value';
 
     private static $testTagKey;
     private static $testTagValue;
@@ -81,6 +89,8 @@ class regionalsecretmanagerTest extends TestCase
         self::$testSecretVersionToEnable = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretWithTagToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::$testSecretBindTagToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
+        self::$testSecretWithLabelsToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
+        self::$testSecretWithAnnotationsToCreateName = self::$client->projectLocationSecretName(self::$projectId, self::$locationId, self::randomSecretId());
         self::disableSecretVersion(self::$testSecretVersionToEnable);
 
         self::$testTagKey = self::createTagKey(self::randomSecretId());
@@ -98,6 +108,8 @@ class regionalsecretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretToCreateName);
         self::deleteSecret(self::$testSecretWithTagToCreateName);
         self::deleteSecret(self::$testSecretBindTagToCreateName);
+        self::deleteSecret(self::$testSecretWithLabelsToCreateName);
+        self::deleteSecret(self::$testSecretWithAnnotationsToCreateName);
         sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
@@ -461,5 +473,119 @@ class regionalsecretmanagerTest extends TestCase
 
         $this->assertStringContainsString('Created secret', $output);
         $this->assertStringContainsString('Tag binding created for secret', $output);
+    }
+
+    public function testCreateSecretWithLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('create_regional_secret_with_labels', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testLabelKey,
+            self::$testLabelValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testCreateSecretWithAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('create_regional_secret_with_annotations', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testAnnotationKey,
+            self::$testAnnotationValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testViewSecretAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('view_regional_secret_annotations', [
+            $name['project'],
+            $name['location'],
+            $name['secret']
+        ]);
+
+        $this->assertStringContainsString('Get secret', $output);
+    }
+
+    public function testViewSecretLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('view_regional_secret_labels', [
+            $name['project'],
+            $name['location'],
+            $name['secret']
+        ]);
+
+        $this->assertStringContainsString('Get secret', $output);
+    }
+
+    public function testEditSecretLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('edit_regional_secret_labels', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testLabelKey,
+            self::$testUpdatedLabelValue
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testEditSecretAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('edit_regional_secret_annotations', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testAnnotationKey,
+            self::$testUpdatedAnnotationValue
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testDeleteSecretLabel()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('delete_regional_secret_label', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testLabelKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testDeleteSecretAnnotation()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('delete_regional_secret_annotation', [
+            $name['project'],
+            $name['location'],
+            $name['secret'],
+            self::$testAnnotationKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
     }
 }

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -60,8 +60,16 @@ class secretmanagerTest extends TestCase
     private static $testSecretVersionToEnable;
     private static $testSecretWithTagToCreateName;
     private static $testSecretBindTagToCreateName;
+    private static $testSecretWithLabelsToCreateName;
+    private static $testSecretWithAnnotationsToCreateName;
 
     private static $iamUser = 'user:sethvargo@google.com';
+    private static $testLabelKey = 'test-label-key';
+    private static $testLabelValue = 'test-label-value';
+    private static $testUpdatedLabelValue = 'test-label-new-value';
+    private static $testAnnotationKey = 'test-annotation-key';
+    private static $testAnnotationValue = 'test-annotation-value';
+    private static $testUpdatedAnnotationValue = 'test-annotation-new-value';
 
     private static $testTagKey;
     private static $testTagValue;
@@ -79,6 +87,8 @@ class secretmanagerTest extends TestCase
         self::$testUmmrSecretToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testSecretWithTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testSecretBindTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretWithLabelsToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretWithAnnotationsToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
 
         self::$testSecretVersion = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDestroy = self::addSecretVersion(self::$testSecretWithVersions);
@@ -99,6 +109,8 @@ class secretmanagerTest extends TestCase
         self::deleteSecret(self::$testUmmrSecretToCreateName);
         self::deleteSecret(self::$testSecretWithTagToCreateName);
         self::deleteSecret(self::$testSecretBindTagToCreateName);
+        self::deleteSecret(self::$testSecretWithLabelsToCreateName);
+        self::deleteSecret(self::$testSecretWithAnnotationsToCreateName);
         sleep(15); // Added a sleep to wait for the tag unbinding
         self::deleteTagValue();
         self::deleteTagKey();
@@ -463,5 +475,111 @@ class secretmanagerTest extends TestCase
 
         $this->assertStringContainsString('Created secret', $output);
         $this->assertStringContainsString('Tag binding created for secret', $output);
+    }
+
+    public function testCreateSecretWithLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('create_secret_with_labels', [
+            $name['project'],
+            $name['secret'],
+            self::$testLabelKey,
+            self::$testLabelValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testCreateSecretWithAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('create_secret_with_annotations', [
+            $name['project'],
+            $name['secret'],
+            self::$testAnnotationKey,
+            self::$testAnnotationValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testViewSecretAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('view_secret_annotations', [
+            $name['project'],
+            $name['secret']
+        ]);
+
+        $this->assertStringContainsString('Get secret', $output);
+    }
+
+    public function testViewSecretLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('view_secret_labels', [
+            $name['project'],
+            $name['secret']
+        ]);
+
+        $this->assertStringContainsString('Get secret', $output);
+    }
+
+    public function testEditSecretLabels()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('edit_secret_labels', [
+            $name['project'],
+            $name['secret'],
+            self::$testLabelKey,
+            self::$testUpdatedLabelValue
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testEditSecretAnnotations()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('edit_secret_annotations', [
+            $name['project'],
+            $name['secret'],
+            self::$testAnnotationKey,
+            self::$testUpdatedAnnotationValue
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testDeleteSecretLabel()
+    {
+        $name = self::$client->parseName(self::$testSecretWithLabelsToCreateName);
+
+        $output = $this->runFunctionSnippet('delete_secret_label', [
+            $name['project'],
+            $name['secret'],
+            self::$testLabelKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testDeleteSecretAnnotation()
+    {
+        $name = self::$client->parseName(self::$testSecretWithAnnotationsToCreateName);
+
+        $output = $this->runFunctionSnippet('delete_secret_annotation', [
+            $name['project'],
+            $name['secret'],
+            self::$testAnnotationKey
+        ]);
+
+        $this->assertStringContainsString('Updated secret', $output);
     }
 }

--- a/secretmanager/test/secretmanagerTest.php
+++ b/secretmanager/test/secretmanagerTest.php
@@ -20,6 +20,14 @@ declare(strict_types=1);
 namespace Google\Cloud\Samples\SecretManager;
 
 use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ResourceManager\V3\DeleteTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\DeleteTagValueRequest;
+use Google\Cloud\ResourceManager\V3\Client\TagKeysClient;
+use Google\Cloud\ResourceManager\V3\CreateTagKeyRequest;
+use Google\Cloud\ResourceManager\V3\TagKey;
+use Google\Cloud\ResourceManager\V3\Client\TagValuesClient;
+use Google\Cloud\ResourceManager\V3\CreateTagValueRequest;
+use Google\Cloud\ResourceManager\V3\TagValue;
 use Google\Cloud\SecretManager\V1\AddSecretVersionRequest;
 use Google\Cloud\SecretManager\V1\Client\SecretManagerServiceClient;
 use Google\Cloud\SecretManager\V1\CreateSecretRequest;
@@ -38,6 +46,9 @@ class secretmanagerTest extends TestCase
     use TestTrait;
 
     private static $client;
+    private static $tagKeyClient;
+    private static $tagValuesClient;
+
     private static $testSecret;
     private static $testSecretToDelete;
     private static $testSecretWithVersions;
@@ -47,24 +58,36 @@ class secretmanagerTest extends TestCase
     private static $testSecretVersionToDestroy;
     private static $testSecretVersionToDisable;
     private static $testSecretVersionToEnable;
+    private static $testSecretWithTagToCreateName;
+    private static $testSecretBindTagToCreateName;
 
     private static $iamUser = 'user:sethvargo@google.com';
+
+    private static $testTagKey;
+    private static $testTagValue;
 
     public static function setUpBeforeClass(): void
     {
         self::$client = new SecretManagerServiceClient();
+        self::$tagKeyClient = new TagKeysClient();
+        self::$tagValuesClient = new TagValuesClient();
 
         self::$testSecret = self::createSecret();
         self::$testSecretToDelete = self::createSecret();
         self::$testSecretWithVersions = self::createSecret();
         self::$testSecretToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
         self::$testUmmrSecretToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretWithTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
+        self::$testSecretBindTagToCreateName = self::$client->secretName(self::$projectId, self::randomSecretId());
 
         self::$testSecretVersion = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDestroy = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToDisable = self::addSecretVersion(self::$testSecretWithVersions);
         self::$testSecretVersionToEnable = self::addSecretVersion(self::$testSecretWithVersions);
         self::disableSecretVersion(self::$testSecretVersionToEnable);
+
+        self::$testTagKey = self::createTagKey(self::randomSecretId());
+        self::$testTagValue = self::createTagValue(self::randomSecretId());
     }
 
     public static function tearDownAfterClass(): void
@@ -74,6 +97,11 @@ class secretmanagerTest extends TestCase
         self::deleteSecret(self::$testSecretWithVersions->getName());
         self::deleteSecret(self::$testSecretToCreateName);
         self::deleteSecret(self::$testUmmrSecretToCreateName);
+        self::deleteSecret(self::$testSecretWithTagToCreateName);
+        self::deleteSecret(self::$testSecretBindTagToCreateName);
+        sleep(15); // Added a sleep to wait for the tag unbinding
+        self::deleteTagValue();
+        self::deleteTagKey();
     }
 
     private static function randomSecretId(): string
@@ -124,6 +152,86 @@ class secretmanagerTest extends TestCase
             if ($e->getStatus() != 'NOT_FOUND') {
                 throw $e;
             }
+        }
+    }
+
+    private static function createTagKey(string $short_name): string
+    {
+        $parent = self::$client->projectName(self::$projectId);
+        $tagKey = (new TagKey())
+            ->setParent($parent)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagKeyRequest())
+            ->setTagKey($tagKey);
+
+        $operation = self::$tagKeyClient->createTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagKey = $operation->getResult();
+            printf("Tag key created: %s\n", $createdTagKey->getName());
+            return $createdTagKey->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag key: %s\n", $error->getMessage());
+            return '';
+        }
+    }
+
+    private static function createTagValue(string $short_name): string
+    {
+        $tagValuesClient = new TagValuesClient();
+        $tagValue = (new TagValue())
+            ->setParent(self::$testTagKey)
+            ->setShortName($short_name);
+
+        $request = (new CreateTagValueRequest())
+            ->setTagValue($tagValue);
+
+        $operation = self::$tagValuesClient->createTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            $createdTagValue = $operation->getResult();
+            printf("Tag value created: %s\n", $createdTagValue->getName());
+            return $createdTagValue->getName();
+        } else {
+            $error = $operation->getError();
+            printf("Error creating tag value: %s\n", $error->getMessage());
+            return '';
+        }
+    }
+
+    private static function deleteTagKey()
+    {
+        $request = (new DeleteTagKeyRequest())
+            ->setName(self::$testTagKey);
+
+        $operation = self::$tagKeyClient->deleteTagKey($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag key deleted: %s\n", self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag key: %s\n", $error->getMessage());
+        }
+    }
+
+    private static function deleteTagValue()
+    {
+        $request = (new DeleteTagValueRequest())
+            ->setName(self::$testTagValue);
+
+        $operation = self::$tagValuesClient->deleteTagValue($request);
+        $operation->pollUntilComplete();
+
+        if ($operation->operationSucceeded()) {
+            printf("Tag value deleted: %s\n", self::$testTagValue);
+        } else {
+            $error = $operation->getError();
+            printf("Error deleting tag value: %s\n", $error->getMessage());
         }
     }
 
@@ -327,5 +435,33 @@ class secretmanagerTest extends TestCase
         ]);
 
         $this->assertStringContainsString('Updated secret', $output);
+    }
+
+    public function testCreateSecretWithTags()
+    {
+        $name = self::$client->parseName(self::$testSecretWithTagToCreateName);
+
+        $output = $this->runFunctionSnippet('create_secret_with_tags', [
+            $name['project'],
+            $name['secret'],
+            self::$testTagKey,
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+    }
+
+    public function testBindTagsToSecret()
+    {
+        $name = self::$client->parseName(self::$testSecretBindTagToCreateName);
+
+        $output = $this->runFunctionSnippet('bind_tags_to_secret', [
+            $name['project'],
+            $name['secret'],
+            self::$testTagValue
+        ]);
+
+        $this->assertStringContainsString('Created secret', $output);
+        $this->assertStringContainsString('Tag binding created for secret', $output);
     }
 }

--- a/spanner/src/pg_update_dml_returning.php
+++ b/spanner/src/pg_update_dml_returning.php
@@ -48,7 +48,7 @@ function pg_update_dml_returning(string $instanceId, string $databaseId): void
     $result = $transaction->execute(
         'UPDATE Albums '
         . 'SET MarketingBudget = MarketingBudget * 2 '
-        . 'WHERE SingerId = 1 and AlbumId = 1'
+        . 'WHERE SingerId = 1 and AlbumId = 1 '
         . 'RETURNING MarketingBudget'
     );
     foreach ($result->rows() as $row) {

--- a/storagecontrol/README.md
+++ b/storagecontrol/README.md
@@ -58,3 +58,7 @@ to [browse the source][google-cloud-php-source] and  [report issues][google-clou
 ## Licensing
 
 * See [LICENSE](../../LICENSE)
+
+## Note
+
+Tests for Anywhere cache Sample are not included due to the long operation times typical for cache operations.

--- a/storagecontrol/README.md
+++ b/storagecontrol/README.md
@@ -58,7 +58,3 @@ to [browse the source][google-cloud-php-source] and  [report issues][google-clou
 ## Licensing
 
 * See [LICENSE](../../LICENSE)
-
-## Note
-
-Tests for Anywhere cache Sample are not included due to the long operation times typical for cache operations.

--- a/storagecontrol/composer.json
+++ b/storagecontrol/composer.json
@@ -3,6 +3,6 @@
         "google/cloud-storage-control": "1.3.0"
     },
     "require-dev": {
-        "google/cloud-storage": "^1.41.3"
+        "google/cloud-storage": "^1.48.1"
     }
 }

--- a/storagecontrol/src/create_anywhere_cache.php
+++ b/storagecontrol/src/create_anywhere_cache.php
@@ -28,6 +28,7 @@ namespace Google\Cloud\Samples\StorageControl;
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
 use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheRequest;
+use Google\ApiCore\Operation;
 
 /**
  * Creates an Anywhere Cache instance.

--- a/storagecontrol/src/create_anywhere_cache.php
+++ b/storagecontrol/src/create_anywhere_cache.php
@@ -28,7 +28,6 @@ namespace Google\Cloud\Samples\StorageControl;
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
 use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheRequest;
-use Google\ApiCore\Operation;
 
 /**
  * Creates an Anywhere Cache instance.
@@ -57,7 +56,6 @@ function create_anywhere_cache(string $bucketName, string $zone): void
     // Start a create operation and block until it completes. Real applications
     // may want to setup a callback, wait on a coroutine, or poll until it
     // completes.
-    /** @var Operation $operation */
     $operation = $storageControlClient->createAnywhereCache($request);
 
     printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());

--- a/storagecontrol/src/create_anywhere_cache.php
+++ b/storagecontrol/src/create_anywhere_cache.php
@@ -27,6 +27,7 @@ namespace Google\Cloud\Samples\StorageControl;
 # [START storage_control_create_anywhere_cache]
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheMetadata;
 use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheRequest;
 
 /**
@@ -56,9 +57,15 @@ function create_anywhere_cache(string $bucketName, string $zone): void
     // Start a create operation and block until it completes. Real applications
     // may want to setup a callback, wait on a coroutine, or poll until it
     // completes.
-    $response = $storageControlClient->createAnywhereCache($request);
+    $operation = $storageControlClient->createAnywhereCache($request);
 
-    printf('Created anywhere cache: %s', $response->getName());
+    printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());
+    $operation->pollUntilComplete();
+
+    // var_dump($operation);exit;
+    /** @var CreateAnywhereCacheMetadata */
+    $metadata = $operation->getMetadata();
+    printf('Created anywhere cache: %s' . PHP_EOL, $metadata->getAnywhereCacheId());
 }
 # [END storage_control_create_anywhere_cache]
 

--- a/storagecontrol/src/create_anywhere_cache.php
+++ b/storagecontrol/src/create_anywhere_cache.php
@@ -27,7 +27,6 @@ namespace Google\Cloud\Samples\StorageControl;
 # [START storage_control_create_anywhere_cache]
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
-use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheMetadata;
 use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheRequest;
 
 /**
@@ -57,15 +56,20 @@ function create_anywhere_cache(string $bucketName, string $zone): void
     // Start a create operation and block until it completes. Real applications
     // may want to setup a callback, wait on a coroutine, or poll until it
     // completes.
+    /** @var Operation $operation */
     $operation = $storageControlClient->createAnywhereCache($request);
 
     printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());
-    $operation->pollUntilComplete();
+    $operation->pollUntilComplete([
+        'totalPollTimeoutMillis' => 5400000,
+        'initialPollDelayMillis' => 1000, // Start with 1 second delay
+        'pollDelayMultiplier' => 2,      // Double delay each time
+        'maxPollDelayMillis' => 60000,   // Max 60 seconds delay between polls
+    ]);
 
-    // var_dump($operation);exit;
-    /** @var CreateAnywhereCacheMetadata */
-    $metadata = $operation->getMetadata();
-    printf('Created anywhere cache: %s' . PHP_EOL, $metadata->getAnywhereCacheId());
+    /** @var AnywhereCache $anywhereCacheResult */
+    $anywhereCacheResult = $operation->getResult();
+    printf('Created anywhere cache: %s' . PHP_EOL, $anywhereCacheResult->getName());
 }
 # [END storage_control_create_anywhere_cache]
 

--- a/storagecontrol/src/create_anywhere_cache.php
+++ b/storagecontrol/src/create_anywhere_cache.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_create_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\AnywhereCache;
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\CreateAnywhereCacheRequest;
+
+/**
+ * Creates an Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $zone The zone in which the cache instance is running.
+ *        (e.g. 'us-east1-b')
+ */
+function create_anywhere_cache(string $bucketName, string $zone): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->bucketName('_', $bucketName);
+
+    $anywhereCache = new AnywhereCache([
+        'zone' => $zone,
+    ]);
+
+    $request = new CreateAnywhereCacheRequest([
+        'parent' => $formattedName,
+        'anywhere_cache' => $anywhereCache,
+    ]);
+
+    // Start a create operation and block until it completes. Real applications
+    // may want to setup a callback, wait on a coroutine, or poll until it
+    // completes.
+    $response = $storageControlClient->createAnywhereCache($request);
+
+    printf('Created anywhere cache: %s', $response->getName());
+}
+# [END storage_control_create_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/disable_anywhere_cache.php
+++ b/storagecontrol/src/disable_anywhere_cache.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_disable_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\DisableAnywhereCacheRequest;
+
+/**
+ * Disables an Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $anywhereCacheId Uniquely identifies the cache.
+ *       (e.g. 'us-east1-b')
+ */
+function disable_anywhere_cache(string $bucketName, string $anywhereCacheId): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->anywhereCacheName('_', $bucketName, $anywhereCacheId);
+
+    $request = new DisableAnywhereCacheRequest([
+        'name' => $formattedName
+    ]);
+
+    $response = $storageControlClient->disableAnywhereCache($request);
+
+    printf('Disabled anywhere cache: %s', $response->getName());
+}
+# [END storage_control_disable_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/get_anywhere_cache.php
+++ b/storagecontrol/src/get_anywhere_cache.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_get_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\GetAnywhereCacheRequest;
+
+/**
+ * Gets an Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $anywhereCacheId Uniquely identifies the cache.
+ *        (e.g. 'us-east1-b')
+ */
+function get_anywhere_cache(string $bucketName, string $anywhereCacheId): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->anywhereCacheName('_', $bucketName, $anywhereCacheId);
+
+    $request = new GetAnywhereCacheRequest([
+        'name' => $formattedName,
+    ]);
+
+    $response = $storageControlClient->getAnywhereCache($request);
+
+    printf('Got anywhere cache: %s', $response->getName());
+}
+# [END storage_control_get_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/list_anywhere_caches.php
+++ b/storagecontrol/src/list_anywhere_caches.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_list_anywhere_caches]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\ListAnywhereCachesRequest;
+
+/**
+ * Lists Anywhere Cache instances for a given bucket.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ */
+function list_anywhere_caches(string $bucketName): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->bucketName('_', $bucketName);
+
+    $request = new ListAnywhereCachesRequest([
+        'parent' => $formattedName,
+    ]);
+
+    $response = $storageControlClient->listAnywhereCaches($request);
+
+    foreach ($response as $anywhereCache) {
+        printf('Anywhere cache name: %s' . PHP_EOL, $anywhereCache->getName());
+    }
+}
+# [END storage_control_list_anywhere_caches]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/pause_anywhere_cache.php
+++ b/storagecontrol/src/pause_anywhere_cache.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_pause_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\PauseAnywhereCacheRequest;
+
+/**
+ * Pauses an Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $anywhereCacheId Uniquely identifies the cache.
+ *        (e.g. 'us-east1-b')
+ */
+function pause_anywhere_cache(string $bucketName, string $anywhereCacheId): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->anywhereCacheName('_', $bucketName, $anywhereCacheId);
+
+    $request = new PauseAnywhereCacheRequest([
+        'name' => $formattedName,
+    ]);
+
+    $response = $storageControlClient->pauseAnywhereCache($request);
+
+    printf('Paused anywhere cache: %s', $response->getName());
+}
+# [END storage_control_pause_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/resume_anywhere_cache.php
+++ b/storagecontrol/src/resume_anywhere_cache.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_resume_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\ResumeAnywhereCacheRequest;
+
+/**
+ * Resumes a disabled or paused Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $anywhereCacheId Uniquely identifies the cache.
+ *        (e.g. 'us-east1-b')
+ */
+function resume_anywhere_cache(string $bucketName, string $anywhereCacheId): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->anywhereCacheName('_', $bucketName, $anywhereCacheId);
+
+    $request = new ResumeAnywhereCacheRequest([
+        'name' => $formattedName
+    ]);
+
+    $response = $storageControlClient->resumeAnywhereCache($request);
+
+    printf('Resumed anywhere cache: %s', $response->getName());
+}
+# [END storage_control_resume_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/src/update_anywhere_cache.php
+++ b/storagecontrol/src/update_anywhere_cache.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2025 Google LLC
  *
@@ -26,7 +27,6 @@ namespace Google\Cloud\Samples\StorageControl;
 # [START storage_control_update_anywhere_cache]
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
-use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheMetadata;
 use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheRequest;
 use Google\Protobuf\FieldMask;
 
@@ -56,23 +56,25 @@ function update_anywhere_cache(string $bucketName, string $anywhereCacheId, stri
         'paths' => ['admission_policy'],
     ]);
 
-    // Start an update operation and block until it completes. Real applications
-    // may want to setup a callback, wait on a coroutine, or poll until it
-    // completes.
     $request = new UpdateAnywhereCacheRequest([
         'anywhere_cache' => $anywhereCache,
         'update_mask' => $updateMask,
     ]);
 
+    // Start an update operation. This returns an Operation object which can be polled.
+    /** @var Operation $operation */
     $operation = $storageControlClient->updateAnywhereCache($request);
 
     printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());
-    $operation->pollUntilComplete();
+    $operation->pollUntilComplete([
+        'totalPollTimeoutMillis' => 5400000,
+        'initialPollDelayMillis' => 1000, // Start with 1 second delay
+        'pollDelayMultiplier' => 2,      // Double delay each time
+        'maxPollDelayMillis' => 60000,   // Max 60 seconds delay between polls
+    ]);
 
-    // var_dump($operation);exit;
-    /** @var UpdateAnywhereCacheMetadata */
-    $metadata = $operation->getMetadata();
-    printf('Updated anywhere cache: %s', $metadata->getAnywhereCacheId());
+    $anywhereCacheResult = $operation->getResult();
+    printf('Updated anywhere cache: %s', $anywhereCacheResult->getName());
 }
 # [END storage_control_update_anywhere_cache]
 

--- a/storagecontrol/src/update_anywhere_cache.php
+++ b/storagecontrol/src/update_anywhere_cache.php
@@ -29,7 +29,6 @@ use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
 use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheRequest;
 use Google\Protobuf\FieldMask;
-use Google\ApiCore\Operation;
 
 /**
  * Updates an Anywhere Cache instance.
@@ -63,7 +62,6 @@ function update_anywhere_cache(string $bucketName, string $anywhereCacheId, stri
     ]);
 
     // Start an update operation. This returns an Operation object which can be polled.
-    /** @var Operation $operation */
     $operation = $storageControlClient->updateAnywhereCache($request);
 
     printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());

--- a/storagecontrol/src/update_anywhere_cache.php
+++ b/storagecontrol/src/update_anywhere_cache.php
@@ -29,6 +29,7 @@ use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
 use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheRequest;
 use Google\Protobuf\FieldMask;
+use Google\ApiCore\Operation;
 
 /**
  * Updates an Anywhere Cache instance.

--- a/storagecontrol/src/update_anywhere_cache.php
+++ b/storagecontrol/src/update_anywhere_cache.php
@@ -26,6 +26,7 @@ namespace Google\Cloud\Samples\StorageControl;
 # [START storage_control_update_anywhere_cache]
 use Google\Cloud\Storage\Control\V2\AnywhereCache;
 use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheMetadata;
 use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheRequest;
 use Google\Protobuf\FieldMask;
 
@@ -63,9 +64,15 @@ function update_anywhere_cache(string $bucketName, string $anywhereCacheId, stri
         'update_mask' => $updateMask,
     ]);
 
-    $response = $storageControlClient->updateAnywhereCache($request);
+    $operation = $storageControlClient->updateAnywhereCache($request);
 
-    printf('Updated anywhere cache: %s', $response->getName());
+    printf('Waiting for operation %s to complete...' . PHP_EOL, $operation->getName());
+    $operation->pollUntilComplete();
+
+    // var_dump($operation);exit;
+    /** @var UpdateAnywhereCacheMetadata */
+    $metadata = $operation->getMetadata();
+    printf('Updated anywhere cache: %s', $metadata->getAnywhereCacheId());
 }
 # [END storage_control_update_anywhere_cache]
 

--- a/storagecontrol/src/update_anywhere_cache.php
+++ b/storagecontrol/src/update_anywhere_cache.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storagecontrol/README.md
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+# [START storage_control_update_anywhere_cache]
+use Google\Cloud\Storage\Control\V2\AnywhereCache;
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\Control\V2\UpdateAnywhereCacheRequest;
+use Google\Protobuf\FieldMask;
+
+/**
+ * Updates an Anywhere Cache instance.
+ *
+ * @param string $bucketName The name of your Cloud Storage bucket.
+ *        (e.g. 'my-bucket')
+ * @param string $anywhereCacheId Uniquely identifies the cache.
+ *        (e.g. 'us-east1-b')
+ * @param string $admission_policy The cache's admission policy.
+ *        (e.g. 'admit-on-first-miss')
+ */
+function update_anywhere_cache(string $bucketName, string $anywhereCacheId, string $admission_policy): void
+{
+    $storageControlClient = new StorageControlClient();
+
+    // Set project to "_" to signify global bucket
+    $formattedName = $storageControlClient->anywhereCacheName('_', $bucketName, $anywhereCacheId);
+
+    $anywhereCache = new AnywhereCache([
+        'name' => $formattedName,
+        'admission_policy' => $admission_policy,
+    ]);
+
+    $updateMask = new FieldMask([
+        'paths' => ['admission_policy'],
+    ]);
+
+    // Start an update operation and block until it completes. Real applications
+    // may want to setup a callback, wait on a coroutine, or poll until it
+    // completes.
+    $request = new UpdateAnywhereCacheRequest([
+        'anywhere_cache' => $anywhereCache,
+        'update_mask' => $updateMask,
+    ]);
+
+    $response = $storageControlClient->updateAnywhereCache($request);
+
+    printf('Updated anywhere cache: %s', $response->getName());
+}
+# [END storage_control_update_anywhere_cache]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storagecontrol/test/anywhereCacheTest.php
+++ b/storagecontrol/test/anywhereCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2025 Google Inc.
  *
@@ -45,7 +46,7 @@ class anywhereCacheTest extends TestCase
         self::$location = 'us-west1';
         self::$zone = 'us-west1-b';
         $uniqueBucketId = time() . rand();
-        self::$cacheId = sprintf('php-anywhere-cache-%s', time() . rand());
+        self::$cacheId = self::$zone;
         self::$sourceBucket = self::$storage->createBucket(
             sprintf('php-gcscontrol-sample-%s', $uniqueBucketId),
             [
@@ -56,7 +57,7 @@ class anywhereCacheTest extends TestCase
         );
         self::$anywhereCacheName = self::$storageControlClient->anywhereCacheName(
             '_', // Set project to "_" to signify global bucket
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId
         );
     }
@@ -77,7 +78,7 @@ class anywhereCacheTest extends TestCase
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Created Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Created anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -88,12 +89,12 @@ class anywhereCacheTest extends TestCase
     public function testGetAnywhereCache()
     {
         $output = $this->runFunctionSnippet('get_anywhere_cache', [
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId,
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Got Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Got anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -104,11 +105,11 @@ class anywhereCacheTest extends TestCase
     public function testListAnywhereCaches()
     {
         $output = $this->runFunctionSnippet('list_anywhere_caches', [
-            self::$location,
+            self::$sourceBucket->name(),
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Listed Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Anywhere cache name: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -119,12 +120,12 @@ class anywhereCacheTest extends TestCase
     public function testPauseAnywhereCache()
     {
         $output = $this->runFunctionSnippet('pause_anywhere_cache', [
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId,
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Paused Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Paused anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -135,12 +136,12 @@ class anywhereCacheTest extends TestCase
     public function testResumeAnywhereCache()
     {
         $output = $this->runFunctionSnippet('resume_anywhere_cache', [
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId,
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Resumed Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Resumed anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -150,14 +151,15 @@ class anywhereCacheTest extends TestCase
      */
     public function testUpdateAnywhereCache()
     {
+        $admission_policy = 'admit-on-second-miss';
         $output = $this->runFunctionSnippet('update_anywhere_cache', [
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId,
-            '7200s'
+            $admission_policy
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Updated Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Updated anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }
@@ -168,12 +170,12 @@ class anywhereCacheTest extends TestCase
     public function testDisableAnywhereCache()
     {
         $output = $this->runFunctionSnippet('disable_anywhere_cache', [
-            self::$location,
+            self::$sourceBucket->name(),
             self::$cacheId,
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Disabled Anywhere Cache: %s', self::$anywhereCacheName),
+            sprintf('Disabled anywhere cache: %s', self::$anywhereCacheName),
             $output
         );
     }

--- a/storagecontrol/test/anywhereCacheTest.php
+++ b/storagecontrol/test/anywhereCacheTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Samples\StorageControl;
+
+use Google\Cloud\Storage\Control\V2\Client\StorageControlClient;
+use Google\Cloud\Storage\StorageClient;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for storage control library samples.
+ */
+class anywhereCacheTest extends TestCase
+{
+    use TestTrait;
+
+    private static $sourceBucket;
+    private static $storage;
+    private static $storageControlClient;
+    private static $location;
+    private static $zone;
+    private static $cacheId;
+    private static $anywhereCacheName;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::checkProjectEnvVars();
+        self::$storage = new StorageClient();
+        self::$storageControlClient = new StorageControlClient();
+        self::$location = 'us-west1';
+        self::$zone = 'us-west1-b';
+        $uniqueBucketId = time() . rand();
+        self::$cacheId = sprintf('php-anywhere-cache-%s', time() . rand());
+        self::$sourceBucket = self::$storage->createBucket(
+            sprintf('php-gcscontrol-sample-%s', $uniqueBucketId),
+            [
+                'location' => self::$location,
+                'hierarchicalNamespace' => ['enabled' => true],
+                'iamConfiguration' => ['uniformBucketLevelAccess' => ['enabled' => true]]
+            ]
+        );
+        self::$anywhereCacheName = self::$storageControlClient->anywhereCacheName(
+            '_', // Set project to "_" to signify global bucket
+            self::$location,
+            self::$cacheId
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$sourceBucket->objects(['versions' => true]) as $object) {
+            $object->delete();
+        }
+        self::$sourceBucket->delete();
+    }
+
+    public function testCreateAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('create_anywhere_cache', [
+            self::$sourceBucket->name(),
+            self::$zone,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Created Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testCreateAnywhereCache
+     */
+    public function testGetAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('get_anywhere_cache', [
+            self::$location,
+            self::$cacheId,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Got Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testGetAnywhereCache
+     */
+    public function testListAnywhereCaches()
+    {
+        $output = $this->runFunctionSnippet('list_anywhere_caches', [
+            self::$location,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Listed Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testListAnywhereCaches
+     */
+    public function testPauseAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('pause_anywhere_cache', [
+            self::$location,
+            self::$cacheId,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Paused Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testPauseAnywhereCache
+     */
+    public function testResumeAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('resume_anywhere_cache', [
+            self::$location,
+            self::$cacheId,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Resumed Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testResumeAnywhereCache
+     */
+    public function testUpdateAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('update_anywhere_cache', [
+            self::$location,
+            self::$cacheId,
+            '7200s'
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Updated Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+
+    /**
+     * @depends testUpdateAnywhereCache
+     */
+    public function testDisableAnywhereCache()
+    {
+        $output = $this->runFunctionSnippet('disable_anywhere_cache', [
+            self::$location,
+            self::$cacheId,
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Disabled Anywhere Cache: %s', self::$anywhereCacheName),
+            $output
+        );
+    }
+}


### PR DESCRIPTION
This internal PR adds sample code for the anywhere cache feature, allowing users to:

- [ ] Create anywhere cache
- [ ] Get anywhere cache
- [ ] List anywhere cache
- [ ] Update anywhere cache
- [ ] Pause anywhere cache
- [ ] Disable anywhere cache
- [ ] Resume anywhere cache

> [!NOTE]
> Sample tests are not included because of the long operation time.