### PR TITLE
Feat(storage): add bucket encryption enforcement

### DIFF
--- a/storage/src/get_bucket_encryption_enforcement_config.php
+++ b/storage/src/get_bucket_encryption_enforcement_config.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_get_encryption_enforcement_config]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Retrieves the current encryption enforcement configurations for a bucket.
+ * 
+ * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
+ */
+function get_bucket_encryption_enforcement_config(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+    $metadata = $bucket->info();
+
+    printf('Encryption enforcement configuration for bucket %s.' . PHP_EOL, $bucketName);
+
+    if (!isset($metadata['encryption'])) {
+        print('No encryption configuration found (Default GMEK is active).' . PHP_EOL);
+        return;
+    }
+
+    $enc = $metadata['encryption'];
+    printf('Default KMS Key: %s' . PHP_EOL, $enc['defaultKmsKeyName'] ?? 'None');
+
+    $printConfig = function ($label, $config) {
+        if ($config) {
+            printf('%s:' . PHP_EOL, $label);
+            printf('  Mode: %s' . PHP_EOL, $config['restrictionMode']);
+            printf('  Effective: %s' . PHP_EOL, $config['effectiveTime'] ?? 'N/A');
+        }
+    };
+
+    $printConfig('Google Managed (GMEK) Enforcement', $enc['googleManagedEncryptionEnforcementConfig'] ?? null);
+    $printConfig('Customer Managed (CMEK) Enforcement', $enc['customerManagedEncryptionEnforcementConfig'] ?? null);
+    $printConfig('Customer Supplied (CSEK) Enforcement', $enc['customerSuppliedEncryptionEnforcementConfig'] ?? null);
+}
+# [END storage_get_encryption_enforcement_config]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/get_bucket_encryption_enforcement_config.php
+++ b/storage/src/get_bucket_encryption_enforcement_config.php
@@ -28,7 +28,7 @@ use Google\Cloud\Storage\StorageClient;
 
 /**
  * Retrieves the current encryption enforcement configurations for a bucket.
- * 
+ *
  * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
  */
 function get_bucket_encryption_enforcement_config(string $bucketName): void

--- a/storage/src/get_bucket_encryption_enforcement_config.php
+++ b/storage/src/get_bucket_encryption_enforcement_config.php
@@ -23,7 +23,7 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_get_encryption_enforcement_config]
+# [START storage_get_bucket_encryption_enforcement_config]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -59,7 +59,7 @@ function get_bucket_encryption_enforcement_config(string $bucketName): void
     $printConfig('Customer Managed (CMEK) Enforcement', $enc['customerManagedEncryptionEnforcementConfig'] ?? null);
     $printConfig('Customer Supplied (CSEK) Enforcement', $enc['customerSuppliedEncryptionEnforcementConfig'] ?? null);
 }
-# [END storage_get_encryption_enforcement_config]
+# [END storage_get_bucket_encryption_enforcement_config]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/remove_all_bucket_encryption_enforcement_config.php
+++ b/storage/src/remove_all_bucket_encryption_enforcement_config.php
@@ -28,7 +28,7 @@ use Google\Cloud\Storage\StorageClient;
 
 /**
  * Removes all encryption enforcement configurations from a bucket.
- * 
+ *
  * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
  */
 function remove_all_bucket_encryption_enforcement_config(string $bucketName): void
@@ -36,7 +36,7 @@ function remove_all_bucket_encryption_enforcement_config(string $bucketName): vo
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 
-    // Setting these values to null in an update call will remove the 
+    // Setting these values to null in an update call will remove the
     // specific enforcement policies from the bucket metadata.
     $options = [
         'encryption' => [

--- a/storage/src/remove_all_bucket_encryption_enforcement_config.php
+++ b/storage/src/remove_all_bucket_encryption_enforcement_config.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_remove_all_encryption_enforcement_config]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Removes all encryption enforcement configurations from a bucket.
+ * 
+ * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
+ */
+function remove_all_bucket_encryption_enforcement_config(string $bucketName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    // Setting these values to null in an update call will remove the 
+    // specific enforcement policies from the bucket metadata.
+    $options = [
+        'encryption' => [
+            'defaultKmsKeyName' => null,
+            'googleManagedEncryptionEnforcementConfig' => null,
+            'customerSuppliedEncryptionEnforcementConfig' => null,
+            'customerManagedEncryptionEnforcementConfig' => null,
+        ],
+    ];
+
+    $bucket->update($options);
+
+    printf('Encryption enforcement configuration removed from bucket %s.' . PHP_EOL, $bucketName);
+}
+# [END storage_remove_all_encryption_enforcement_config]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/set_bucket_encryption_enforcement_config.php
+++ b/storage/src/set_bucket_encryption_enforcement_config.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Samples\Storage;
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Configures a bucket to enforce specific encryption types (e.g., CMEK-only).
+ * Creates a bucket with specific encryption enforcement (e.g., CMEK-only).
  *
  * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
  * @param string $kmsKeyName The name of the KMS key to be used as the default (e.g. "projects/my-project/...").
@@ -53,9 +53,9 @@ function set_bucket_encryption_enforcement_config(string $bucketName, string $km
             ],
         ],
     ];
-    $bucket->update($options);
+    $storage->createBucket($bucketName, $options);
 
-    printf('Encryption enforcement configuration updated for bucket %s.' . PHP_EOL, $bucketName);
+    printf('Bucket %s created with encryption enforcement configuration.' . PHP_EOL, $bucketName);
 }
 # [END storage_set_bucket_encryption_enforcement_config]
 

--- a/storage/src/set_bucket_encryption_enforcement_config.php
+++ b/storage/src/set_bucket_encryption_enforcement_config.php
@@ -23,7 +23,7 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_set_encryption_enforcement_config]
+# [START storage_set_bucket_encryption_enforcement_config]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -57,7 +57,7 @@ function set_bucket_encryption_enforcement_config(string $bucketName, string $km
 
     printf('Encryption enforcement configuration updated for bucket %s.' . PHP_EOL, $bucketName);
 }
-# [END storage_set_encryption_enforcement_config]
+# [END storage_set_bucket_encryption_enforcement_config]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/set_bucket_encryption_enforcement_config.php
+++ b/storage/src/set_bucket_encryption_enforcement_config.php
@@ -28,7 +28,7 @@ use Google\Cloud\Storage\StorageClient;
 
 /**
  * Configures a bucket to enforce specific encryption types (e.g., CMEK-only).
- * 
+ *
  * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
  * @param string $kmsKeyName The name of the KMS key to be used as the default (e.g. "projects/my-project/...").
  */
@@ -37,7 +37,7 @@ function set_bucket_encryption_enforcement_config(string $bucketName, string $km
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 
-    // This configuration enforces that all objects uploaded to the bucket 
+    // This configuration enforces that all objects uploaded to the bucket
     // must use Customer Managed Encryption Keys (CMEK).
     $options = [
         'encryption' => [

--- a/storage/src/set_bucket_encryption_enforcement_config.php
+++ b/storage/src/set_bucket_encryption_enforcement_config.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * For instructions on how to run the full sample:
+ *
+ * @see https://github.com/GoogleCloudPlatform/php-docs-samples/tree/main/storage/README.md
+ */
+
+namespace Google\Cloud\Samples\Storage;
+
+# [START storage_set_encryption_enforcement_config]
+use Google\Cloud\Storage\StorageClient;
+
+/**
+ * Configures a bucket to enforce specific encryption types (e.g., CMEK-only).
+ * 
+ * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
+ * @param string $kmsKeyName The name of the KMS key to be used as the default (e.g. "projects/my-project/...").
+ */
+function set_bucket_encryption_enforcement_config(string $bucketName, string $kmsKeyName): void
+{
+    $storage = new StorageClient();
+    $bucket = $storage->bucket($bucketName);
+
+    // This configuration enforces that all objects uploaded to the bucket 
+    // must use Customer Managed Encryption Keys (CMEK).
+    $options = [
+        'encryption' => [
+            'defaultKmsKeyName' => $kmsKeyName,
+            'googleManagedEncryptionEnforcementConfig' => [
+                'restrictionMode' => 'FullyRestricted',
+            ],
+            'customerSuppliedEncryptionEnforcementConfig' => [
+                'restrictionMode' => 'FullyRestricted',
+            ],
+            'customerManagedEncryptionEnforcementConfig' => [
+                'restrictionMode' => 'NotRestricted',
+            ],
+        ],
+    ];
+    $bucket->update($options);
+
+    printf('Encryption enforcement configuration updated for bucket %s.' . PHP_EOL, $bucketName);
+}
+# [END storage_set_encryption_enforcement_config]
+
+// The following 2 lines are only needed to run the samples
+require_once __DIR__ . '/../../testing/sample_helpers.php';
+\Google\Cloud\Samples\execute_sample(__FILE__, __NAMESPACE__, $argv);

--- a/storage/src/update_bucket_encryption_enforcement_config.php
+++ b/storage/src/update_bucket_encryption_enforcement_config.php
@@ -23,7 +23,7 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_update_encryption_enforcement_config]
+# [START storage_update_bucket_encryption_enforcement_config]
 use Google\Cloud\Storage\StorageClient;
 
 /**
@@ -62,7 +62,7 @@ function update_bucket_encryption_enforcement_config(string $bucketName): void
     $bucket->update($clearOptions);
     printf('All encryption enforcement configurations removed from bucket %s.' . PHP_EOL, $bucketName);
 }
-# [END storage_update_encryption_enforcement_config]
+# [END storage_update_bucket_encryption_enforcement_config]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/src/update_bucket_encryption_enforcement_config.php
+++ b/storage/src/update_bucket_encryption_enforcement_config.php
@@ -23,22 +23,34 @@
 
 namespace Google\Cloud\Samples\Storage;
 
-# [START storage_remove_all_encryption_enforcement_config]
+# [START storage_update_encryption_enforcement_config]
 use Google\Cloud\Storage\StorageClient;
 
 /**
- * Removes all encryption enforcement configurations from a bucket.
+ * Updates or removes encryption enforcement configurations from a bucket.
  *
  * @param string $bucketName The ID of your GCS bucket (e.g. "my-bucket").
  */
-function remove_all_bucket_encryption_enforcement_config(string $bucketName): void
+function update_bucket_encryption_enforcement_config(string $bucketName): void
 {
     $storage = new StorageClient();
     $bucket = $storage->bucket($bucketName);
 
-    // Setting these values to null in an update call will remove the
-    // specific enforcement policies from the bucket metadata.
-    $options = [
+    // Update a specific encryption type's restriction mode
+    // This partial update preserves other existing encryption settings.
+    $updateOptions = [
+        'encryption' => [
+            'googleManagedEncryptionEnforcementConfig' => [
+                'restrictionMode' => 'FullyRestricted'
+            ]
+        ]
+    ];
+    $bucket->update($updateOptions);
+    printf('Google-managed encryption enforcement set to FullyRestricted for %s.' . PHP_EOL, $bucketName);
+
+    // Remove all encryption enforcement configurations altogether
+    // Setting these values to null removes the policies from the bucket metadata.
+    $clearOptions = [
         'encryption' => [
             'defaultKmsKeyName' => null,
             'googleManagedEncryptionEnforcementConfig' => null,
@@ -47,11 +59,10 @@ function remove_all_bucket_encryption_enforcement_config(string $bucketName): vo
         ],
     ];
 
-    $bucket->update($options);
-
-    printf('Encryption enforcement configuration removed from bucket %s.' . PHP_EOL, $bucketName);
+    $bucket->update($clearOptions);
+    printf('All encryption enforcement configurations removed from bucket %s.' . PHP_EOL, $bucketName);
 }
-# [END storage_remove_all_encryption_enforcement_config]
+# [END storage_update_encryption_enforcement_config]
 
 // The following 2 lines are only needed to run the samples
 require_once __DIR__ . '/../../testing/sample_helpers.php';

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -624,7 +624,7 @@ class storageTest extends TestCase
         $finalOutput = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
             self::$kmsEncryptedBucketName
         ]);
-        
+
         $this->assertStringContainsString('No encryption configuration found (Default GMEK is active).', $finalOutput);
     }
 

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -573,6 +573,65 @@ class storageTest extends TestCase
         );
     }
 
+    /** @depends testEnableDefaultKmsKey */
+    public function testSetBucketEncryptionEnforcementConfig()
+    {
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+
+        $output = $this->runFunctionSnippet('set_bucket_encryption_enforcement_config', [
+            $kmsEncryptedBucketName,
+            $this->keyName(),
+        ]);
+
+        $this->assertEquals($output, sprintf(
+            'Encryption enforcement configuration updated for bucket %s.' . PHP_EOL,
+            $kmsEncryptedBucketName
+        ));
+    }
+
+    /** @depends testSetBucketEncryptionEnforcementConfig */
+    public function testGetBucketEncryptionEnforcementConfig()
+    {
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+        sleep(2);
+
+        $output = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
+            $kmsEncryptedBucketName
+        ]);
+
+        $this->assertStringContainsString(
+            sprintf('Encryption enforcement configuration for bucket %s.', $kmsEncryptedBucketName),
+            $output
+        );
+        $this->assertStringContainsString(sprintf('Default KMS Key: %s', $this->keyName()), $output);
+        $this->assertStringContainsString('Google Managed (GMEK) Enforcement:', $output);
+        $this->assertStringContainsString('Mode: FullyRestricted', $output);
+        $this->assertStringContainsString('Customer Managed (CMEK) Enforcement:', $output);
+        $this->assertStringContainsString('Mode: NotRestricted', $output);
+    }
+
+    /** @depends testGetBucketEncryptionEnforcementConfig */
+    public function testRemoveAllBucketEncryptionEnforcementConfig()
+    {
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+
+        $output = $this->runFunctionSnippet('remove_all_bucket_encryption_enforcement_config', [
+            $kmsEncryptedBucketName
+        ]);
+
+        $this->assertEquals($output, sprintf(
+            'Encryption enforcement configuration removed from bucket %s.' . PHP_EOL,
+            $kmsEncryptedBucketName
+        ));
+
+        // Final verification: Ensure 'Get' now shows no configuration
+        sleep(1);
+        $finalOutput = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
+            $kmsEncryptedBucketName
+        ]);
+        $this->assertStringContainsString('No encryption configuration found (Default GMEK is active).', $finalOutput);
+    }
+
     public function testBucketVersioning()
     {
         $output = self::runFunctionSnippet('enable_versioning', [

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -32,6 +32,7 @@ class storageTest extends TestCase
     use TestTrait;
 
     private static $bucketName;
+    private static $kmsEncryptedBucketName;
     private static $storage;
     private static $tempBucket;
     private static $objectRetentionBucketName;
@@ -40,6 +41,7 @@ class storageTest extends TestCase
     {
         self::checkProjectEnvVars();
         self::$bucketName = self::requireEnv('GOOGLE_STORAGE_BUCKET');
+        self::$kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
         self::$storage = new StorageClient();
         self::$tempBucket = self::$storage->createBucket(
             sprintf('%s-test-bucket-%s', self::$projectId, time())
@@ -511,16 +513,14 @@ class storageTest extends TestCase
 
     public function testEnableDefaultKmsKey()
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
-
         $output = $this->runFunctionSnippet('enable_default_kms_key', [
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $this->keyName(),
         ]);
 
         $this->assertEquals($output, sprintf(
             'Default KMS key for %s was set to %s' . PHP_EOL,
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $this->keyName()
         ));
     }
@@ -528,14 +528,12 @@ class storageTest extends TestCase
     /** @depends testEnableDefaultKmsKey */
     public function testUploadWithKmsKey()
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
-
         $objectName = 'test-object-' . time();
         $uploadFrom = tempnam(sys_get_temp_dir(), '/tests');
         file_put_contents($uploadFrom, 'foo' . rand());
 
         $output = $this->runFunctionSnippet('upload_with_kms_key', [
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $objectName,
             $uploadFrom,
             $this->keyName(),
@@ -544,7 +542,7 @@ class storageTest extends TestCase
         $this->assertEquals($output, sprintf(
             'Uploaded %s to gs://%s/%s using encryption key %s' . PHP_EOL,
             basename($uploadFrom),
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $objectName,
             $this->keyName()
         ));
@@ -555,12 +553,11 @@ class storageTest extends TestCase
     /** @depends testUploadWithKmsKey */
     public function testObjectGetKmsKey(string $objectName)
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
-        $bucket = self::$storage->bucket($kmsEncryptedBucketName);
+        $bucket = self::$storage->bucket(self::$kmsEncryptedBucketName);
         $objectInfo = $bucket->object($objectName)->info();
 
         $output = $this->runFunctionSnippet('object_get_kms_key', [
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $objectName,
         ]);
 
@@ -576,58 +573,51 @@ class storageTest extends TestCase
     /** @depends testEnableDefaultKmsKey */
     public function testSetBucketEncryptionEnforcementConfig()
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
-
         $output = $this->runFunctionSnippet('set_bucket_encryption_enforcement_config', [
-            $kmsEncryptedBucketName,
+            self::$kmsEncryptedBucketName,
             $this->keyName(),
         ]);
 
         $this->assertEquals($output, sprintf(
             'Encryption enforcement configuration updated for bucket %s.' . PHP_EOL,
-            $kmsEncryptedBucketName
+            self::$kmsEncryptedBucketName
         ));
     }
 
     /** @depends testSetBucketEncryptionEnforcementConfig */
     public function testGetBucketEncryptionEnforcementConfig()
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
         sleep(2);
-
         $output = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
-            $kmsEncryptedBucketName
+            self::$kmsEncryptedBucketName
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Encryption enforcement configuration for bucket %s.', $kmsEncryptedBucketName),
+            sprintf('Encryption enforcement configuration for bucket %s.', self::$kmsEncryptedBucketName),
             $output
         );
         $this->assertStringContainsString(sprintf('Default KMS Key: %s', $this->keyName()), $output);
-        $this->assertStringContainsString('Google Managed (GMEK) Enforcement:', $output);
-        $this->assertStringContainsString('Mode: FullyRestricted', $output);
-        $this->assertStringContainsString('Customer Managed (CMEK) Enforcement:', $output);
-        $this->assertStringContainsString('Mode: NotRestricted', $output);
+        $this->assertStringContainsString('Google Managed (GMEK) Enforcement:' . PHP_EOL . '  Mode: FullyRestricted', $output);
+        $this->assertStringContainsString('Customer Supplied (CSEK) Enforcement:' . PHP_EOL . '  Mode: FullyRestricted', $output);
+        $this->assertStringContainsString('Customer Managed (CMEK) Enforcement:' . PHP_EOL . '  Mode: NotRestricted', $output);
     }
 
     /** @depends testGetBucketEncryptionEnforcementConfig */
     public function testRemoveAllBucketEncryptionEnforcementConfig()
     {
-        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
-
         $output = $this->runFunctionSnippet('remove_all_bucket_encryption_enforcement_config', [
-            $kmsEncryptedBucketName
+            self::$kmsEncryptedBucketName
         ]);
 
         $this->assertEquals($output, sprintf(
             'Encryption enforcement configuration removed from bucket %s.' . PHP_EOL,
-            $kmsEncryptedBucketName
+            self::$kmsEncryptedBucketName
         ));
 
         // Final verification: Ensure 'Get' now shows no configuration
         sleep(1);
         $finalOutput = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
-            $kmsEncryptedBucketName
+            self::$kmsEncryptedBucketName
         ]);
         $this->assertStringContainsString('No encryption configuration found (Default GMEK is active).', $finalOutput);
     }

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -603,22 +603,28 @@ class storageTest extends TestCase
     }
 
     /** @depends testGetBucketEncryptionEnforcementConfig */
-    public function testRemoveAllBucketEncryptionEnforcementConfig()
+    public function testUpdateBucketEncryptionEnforcementConfig()
     {
-        $output = $this->runFunctionSnippet('remove_all_bucket_encryption_enforcement_config', [
+        $output = $this->runFunctionSnippet('update_bucket_encryption_enforcement_config', [
             self::$kmsEncryptedBucketName
         ]);
 
-        $this->assertEquals($output, sprintf(
-            'Encryption enforcement configuration removed from bucket %s.' . PHP_EOL,
-            self::$kmsEncryptedBucketName
-        ));
+        $this->assertStringContainsString(
+            sprintf('Google-managed encryption enforcement set to FullyRestricted for %s.', self::$kmsEncryptedBucketName),
+            $output
+        );
+
+        $this->assertStringContainsString(
+            sprintf('All encryption enforcement configurations removed from bucket %s.', self::$kmsEncryptedBucketName),
+            $output
+        );
 
         // Final verification: Ensure 'Get' now shows no configuration
-        sleep(1);
+        sleep(2);
         $finalOutput = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
             self::$kmsEncryptedBucketName
         ]);
+        
         $this->assertStringContainsString('No encryption configuration found (Default GMEK is active).', $finalOutput);
     }
 

--- a/storage/test/storageTest.php
+++ b/storage/test/storageTest.php
@@ -32,7 +32,6 @@ class storageTest extends TestCase
     use TestTrait;
 
     private static $bucketName;
-    private static $kmsEncryptedBucketName;
     private static $storage;
     private static $tempBucket;
     private static $objectRetentionBucketName;
@@ -41,7 +40,6 @@ class storageTest extends TestCase
     {
         self::checkProjectEnvVars();
         self::$bucketName = self::requireEnv('GOOGLE_STORAGE_BUCKET');
-        self::$kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
         self::$storage = new StorageClient();
         self::$tempBucket = self::$storage->createBucket(
             sprintf('%s-test-bucket-%s', self::$projectId, time())
@@ -513,14 +511,16 @@ class storageTest extends TestCase
 
     public function testEnableDefaultKmsKey()
     {
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+
         $output = $this->runFunctionSnippet('enable_default_kms_key', [
-            self::$kmsEncryptedBucketName,
+            $kmsEncryptedBucketName,
             $this->keyName(),
         ]);
 
         $this->assertEquals($output, sprintf(
             'Default KMS key for %s was set to %s' . PHP_EOL,
-            self::$kmsEncryptedBucketName,
+            $kmsEncryptedBucketName,
             $this->keyName()
         ));
     }
@@ -528,12 +528,14 @@ class storageTest extends TestCase
     /** @depends testEnableDefaultKmsKey */
     public function testUploadWithKmsKey()
     {
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+
         $objectName = 'test-object-' . time();
         $uploadFrom = tempnam(sys_get_temp_dir(), '/tests');
         file_put_contents($uploadFrom, 'foo' . rand());
 
         $output = $this->runFunctionSnippet('upload_with_kms_key', [
-            self::$kmsEncryptedBucketName,
+            $kmsEncryptedBucketName,
             $objectName,
             $uploadFrom,
             $this->keyName(),
@@ -542,7 +544,7 @@ class storageTest extends TestCase
         $this->assertEquals($output, sprintf(
             'Uploaded %s to gs://%s/%s using encryption key %s' . PHP_EOL,
             basename($uploadFrom),
-            self::$kmsEncryptedBucketName,
+            $kmsEncryptedBucketName,
             $objectName,
             $this->keyName()
         ));
@@ -553,11 +555,12 @@ class storageTest extends TestCase
     /** @depends testUploadWithKmsKey */
     public function testObjectGetKmsKey(string $objectName)
     {
-        $bucket = self::$storage->bucket(self::$kmsEncryptedBucketName);
+        $kmsEncryptedBucketName = self::$bucketName . '-kms-encrypted';
+        $bucket = self::$storage->bucket($kmsEncryptedBucketName);
         $objectInfo = $bucket->object($objectName)->info();
 
         $output = $this->runFunctionSnippet('object_get_kms_key', [
-            self::$kmsEncryptedBucketName,
+            $kmsEncryptedBucketName,
             $objectName,
         ]);
 
@@ -570,30 +573,33 @@ class storageTest extends TestCase
         );
     }
 
-    /** @depends testEnableDefaultKmsKey */
     public function testSetBucketEncryptionEnforcementConfig()
     {
+        $enforcementBucketName = self::$bucketName . '-enc-enforcement';
+
         $output = $this->runFunctionSnippet('set_bucket_encryption_enforcement_config', [
-            self::$kmsEncryptedBucketName,
+            $enforcementBucketName,
             $this->keyName(),
         ]);
 
         $this->assertEquals($output, sprintf(
-            'Encryption enforcement configuration updated for bucket %s.' . PHP_EOL,
-            self::$kmsEncryptedBucketName
+            'Bucket %s created with encryption enforcement configuration.' . PHP_EOL,
+            $enforcementBucketName
         ));
     }
 
     /** @depends testSetBucketEncryptionEnforcementConfig */
     public function testGetBucketEncryptionEnforcementConfig()
     {
+        $enforcementBucketName = self::$bucketName . '-enc-enforcement';
+
         sleep(2);
         $output = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
-            self::$kmsEncryptedBucketName
+            $enforcementBucketName
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Encryption enforcement configuration for bucket %s.', self::$kmsEncryptedBucketName),
+            sprintf('Encryption enforcement configuration for bucket %s.', $enforcementBucketName),
             $output
         );
         $this->assertStringContainsString(sprintf('Default KMS Key: %s', $this->keyName()), $output);
@@ -605,24 +611,26 @@ class storageTest extends TestCase
     /** @depends testGetBucketEncryptionEnforcementConfig */
     public function testUpdateBucketEncryptionEnforcementConfig()
     {
+        $enforcementBucketName = self::$bucketName . '-enc-enforcement';
+
         $output = $this->runFunctionSnippet('update_bucket_encryption_enforcement_config', [
-            self::$kmsEncryptedBucketName
+            $enforcementBucketName
         ]);
 
         $this->assertStringContainsString(
-            sprintf('Google-managed encryption enforcement set to FullyRestricted for %s.', self::$kmsEncryptedBucketName),
+            sprintf('Google-managed encryption enforcement set to FullyRestricted for %s.', $enforcementBucketName),
             $output
         );
 
         $this->assertStringContainsString(
-            sprintf('All encryption enforcement configurations removed from bucket %s.', self::$kmsEncryptedBucketName),
+            sprintf('All encryption enforcement configurations removed from bucket %s.', $enforcementBucketName),
             $output
         );
 
         // Final verification: Ensure 'Get' now shows no configuration
         sleep(2);
         $finalOutput = $this->runFunctionSnippet('get_bucket_encryption_enforcement_config', [
-            self::$kmsEncryptedBucketName
+            $enforcementBucketName
         ]);
 
         $this->assertStringContainsString('No encryption configuration found (Default GMEK is active).', $finalOutput);


### PR DESCRIPTION
Adds metadata support for the following encryption enforcement fields:
- googleManagedEncryptionEnforcementConfig
- customerManagedEncryptionEnforcementConfig
- customerSuppliedEncryptionEnforcementConfig